### PR TITLE
Finish query stream on error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,54 +3,41 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:386e5a632be2aa525a327e13694bd22bde42fe6fe925c3bfef89b59c6e10b08f"
   name = "github.com/AndreasBriese/bbloom"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "28f7e881ca57bc00e028f9ede9f0d9104cfeef5e"
 
 [[projects]]
-  digest = "1:9c883d2e7fd391fbc7db7536863cc4cd181a97646b4659e9a7e7aa583c411885"
   name = "github.com/Shopify/sarama"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "35324cf48e33d8260e1c7c18854465a904ade249"
   version = "v1.17.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:a0bcc2589c645af2393d9c567419b55b92738c68af2da39431859989e63bd289"
   name = "github.com/augustoroman/v8"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b371c0b05b97917d55880f2deaa0bc1262d04c0d"
 
 [[projects]]
   branch = "master"
-  digest = "1:8b5b2ef26f194968cadcac09ca84f1275057cca6461af79d1c2547964c634c81"
   name = "github.com/bmeg/golib"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "82a1e1d7a0b26093e4bcdc4522cbf93d9cd5f694"
 
 [[projects]]
-  digest = "1:a12d94258c5298ead75e142e8001224bf029f302fed9e96cd39c0eaf90f3954d"
   name = "github.com/boltdb/bolt"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
   version = "v1.3.1"
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:08ac19c58238c521ce132af2edfa64d75d209267a44ac83f5b23dff8a4381cfd"
   name = "github.com/dgraph-io/badger"
   packages = [
     ".",
@@ -58,123 +45,99 @@
     "protos",
     "skl",
     "table",
-    "y",
+    "y"
   ]
-  pruneopts = "NUT"
   revision = "a6f0866f06a0ef6ac612e427ffe5d081db4e6fab"
   version = "v1.5.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:3bde5c0379e801eefa31b42f0898745c298a25473ab62da93ac94d5da7e4196c"
   name = "github.com/dgryski/go-farm"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2de33835d10275975374b37b2dcfd22c9020a1f5"
 
 [[projects]]
-  digest = "1:e32db9fddc5e745860ca0f4176670d2cf839d3afa06b09ad595b8a99be8b5cb6"
   name = "github.com/dlclark/regexp2"
   packages = [
     ".",
-    "syntax",
+    "syntax"
   ]
-  pruneopts = "NUT"
   revision = "487489b64fb796de2e55f4e8a4ad1e145f80e957"
   version = "v1.1.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:9af09d68bd80a20b3fae068ab7c6476c9b53a145963b57df6d508180aabae7b9"
   name = "github.com/dop251/goja"
   packages = [
     ".",
     "ast",
     "file",
     "parser",
-    "token",
+    "token"
   ]
-  pruneopts = "NUT"
   revision = "9183045acc25574e0dd2ad37d5e7f978b1a4de12"
 
 [[projects]]
-  digest = "1:08143362be979b087c2c1bae5dde986e988d3d5d4dc661727cbe436411b3f33a"
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
-  pruneopts = "NUT"
   revision = "ea41b0fad31007accc7f806884dcdf3da98b79ce"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:033fde904d4c8ea10fba6c3895bea4ae5313f29c484b30146700a25fac62d640"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "040cc1a32f578808623071247fdbd5cc43f37f5f"
 
 [[projects]]
-  digest = "1:0d36a2b325b9e75f8057f7f9fbe778d348d70ba652cb9335485b69d1a5c4e038"
   name = "github.com/eapache/queue"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "44cc805cf13205b55f69e14bcb69867d1ae92f98"
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6be8997d410d48dd045a8c18ee25e59ebfaeb9aa502c240b0d8ad9bb3e3fdd4f"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram",
+    "internal/scram"
   ]
-  pruneopts = "NUT"
   revision = "113d3961e7311526535a1ef7042196563d442761"
 
 [[projects]]
-  digest = "1:7d5c6757be75cd60d5936e26b2894c16bbb555bd8dad4724b0fa19efb3a6f78b"
   name = "github.com/go-sourcemap/sourcemap"
   packages = [
     ".",
-    "internal/base64vlq",
+    "internal/base64vlq"
   ]
-  pruneopts = "NUT"
   revision = "b019cc30c1eaa584753491b0d8f8c1534bf1eb44"
   version = "v2.1.2"
 
 [[projects]]
-  digest = "1:747c1fcb10f8f6734551465ab73c6ed9c551aa6e66250fb6683d1624f554546a"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d523deb1b23d913de5bdada721a6071e71283618"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:8f251d09f52a8920bdba202b0c18a24cafb4f70f94b9afd8d02bf7643cfc99a0"
   name = "github.com/golang/gddo"
   packages = [
     "httputil",
-    "httputil/header",
+    "httputil/header"
   ]
-  pruneopts = "NUT"
   revision = "daffe1f90ec57f8ed69464f9094753fc6452e983"
 
 [[projects]]
-  digest = "1:6aef947ba53156da1a66ee891d70d61835e0dcfc9f0d728ae1132db651e81c22"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -184,22 +147,18 @@
     "ptypes/any",
     "ptypes/duration",
     "ptypes/struct",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:7f114b78210bf5b75f307fc97cff293633c835bab1e0ea8a744a44b39c042dfe"
   name = "github.com/golang/snappy"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:7ebd5fd1451351e650592acecee7eb05516fc319160ef4d2e42d773fe75046f3"
   name = "github.com/graphql-go/graphql"
   packages = [
     ".",
@@ -212,190 +171,150 @@
     "language/printer",
     "language/source",
     "language/typeInfo",
-    "language/visitor",
+    "language/visitor"
   ]
-  pruneopts = "NUT"
   revision = "1e23489041ba90a66f317fe0deccb236a2fff3cb"
   version = "v0.7.5"
 
 [[projects]]
-  digest = "1:eeae01d7aaaabdd5ab150793370f78e919e12640f8cc9a7824c6209cf64a178a"
   name = "github.com/graphql-go/handler"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "f0393b2c10daeebea900292b8e092e73475399d9"
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:607422aa5679ef904f4f28f394b5ca32b55f08dae4b887576902844d1310cddc"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
     "retry",
     "util/backoffutils",
-    "util/metautils",
+    "util/metautils"
   ]
-  pruneopts = "NUT"
   revision = "c250d6563d4d4c20252cd865923440e829844f4e"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:5c3363169fc963321cd0789dda2ddff90562817d277e78011b0e1bbf51a6b473"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "runtime",
     "runtime/internal",
-    "utilities",
+    "utilities"
   ]
-  pruneopts = "NUT"
   revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
   version = "v1.4.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:f0d9d74edbd40fdeada436d5ac9cb5197407899af3fef85ff0137077ffe8ae19"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
-  digest = "1:4d55897d00e9b53c1c716e8fe504de3d21bec8edba0a330bfaa87902695e46e2"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
-  digest = "1:65300ccc4bcb38b107b868155c303312978981e56bca707c81efec57575b5e06"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
-  digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:f8670bc82b370c3dd4a64699bc7157cb66bb7c4f43be06edd5e7e4cc134bfa57"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
-    "reflectx",
+    "reflectx"
   ]
-  pruneopts = "NUT"
   revision = "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849"
 
 [[projects]]
   branch = "master"
-  digest = "1:29b28f180efcbaf57b5a5b91d9299a1f1fa749a8ab0a69fb9bcbf1f58b8749d3"
   name = "github.com/knakk/rdf"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b6ee24f8f40ff0580683aefb6831dad263a3f751"
 
 [[projects]]
-  digest = "1:7b21c7fc5551b46d1308b4ffa9e9e49b66c7a8b0ba88c0130474b0e7a20d859f"
   name = "github.com/kr/pretty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:c3a7836b5904db0f8b609595b619916a6831cb35b8b714aec39f96d00c6155d8"
   name = "github.com/kr/text"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6415011db6d5f89961c38446f3552c74749462bef94904534c55e3dda1affeb9"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid",
+    "oid"
   ]
-  pruneopts = "NUT"
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
   branch = "master"
-  digest = "1:f2079ac1290c01101c5331fe60f824ae57dfeaf53e7174edeb368c2337468743"
   name = "github.com/logrusorgru/aurora"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "d694e6f975a9109e2b063829d563a7c153c4b53c"
 
 [[projects]]
   branch = "master"
-  digest = "1:92b635b2786bcc08f53d2efc953ef32ef695e028aceb03d157ce2a6d468bec2a"
   name = "github.com/mailru/easyjson"
   packages = [
     ".",
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = "NUT"
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
   branch = "master"
-  digest = "1:a9c9c350ae298eb1cc8d92c7e18f39e2e816127ca540f96b5c9dc6f1ffbc05ab"
   name = "github.com/oliveagle/jsonpath"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "2e52cf6e685269ed8aefec6390f3cac3ef74e730"
 
 [[projects]]
-  digest = "1:bf8b95442fa2d448bde39997d6fde56de40344b422d93cea4deead8de699e190"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
-    "internal/xxh32",
+    "internal/xxh32"
   ]
-  pruneopts = "NUT"
   revision = "1958fd8fff7f115e79725b1288e0b878b3e06b00"
   version = "v2.0.3"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:7c522337040d4ec9a136cd9d64fe4677ee1d3eae4a7f8831c2108f9bec43fa48"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   branch = "master"
-  digest = "1:122fdd61e136e89e520052921d535753b34853224de4f4d1482a3578d4fdb541"
   name = "github.com/robertkrimen/otto"
   packages = [
     ".",
@@ -404,62 +323,48 @@
     "file",
     "parser",
     "registry",
-    "token",
+    "token"
   ]
-  pruneopts = "NUT"
   revision = "15f95af6e78dcd2030d8195a138bd88d4f403546"
 
 [[projects]]
-  digest = "1:e131953e0822abeff314f8f7cc869e26dc799d4718aa967c7db120aeb28f58f9"
   name = "github.com/segmentio/ksuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "112f929a3020abfcd06b77c963ec919130796a35"
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:b2339e83ce9b5c4f79405f949429a7f68a9a904fed903c672aac1e7ceb7f5f02"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
-  digest = "1:20998b12ca59a28c75b02dedfe8eaf6e56d0f3cd38d796d6107ca344c1a7024d"
   name = "github.com/spenczar/tdigest"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c30a5bef6c2a91b32b7044b570024f0faf39c959"
   version = "v2.1.0"
 
 [[projects]]
-  digest = "1:343d44e06621142ab09ae0c76c1799104cdfddd3ffb445d78b1adf8dc3ffaf3d"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
 
 [[projects]]
-  digest = "1:bacb8b590716ab7c33f2277240972c9582d389593ee8d66fc10074e0508b8126"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  pruneopts = "NUT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:b3cfb8d82b1601a846417c3f31c03a7961862cb2c98dcf0959c473843e6d9a2b"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -473,30 +378,24 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util",
+    "leveldb/util"
   ]
-  pruneopts = "NUT"
   revision = "c4c61651e9e37fa117f53c5a906d3b63090d8445"
 
 [[projects]]
   branch = "master"
-  digest = "1:2b78b2e3d2ed94b7dbdc5dc7916dbdb4211112dd11d90f753dc5a45b8dabb7ac"
   name = "github.com/tecbot/gorocksdb"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3e476152774442234f9a9f747386a48a1d82a515"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  pruneopts = "NUT"
   revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [[projects]]
   branch = "master"
-  digest = "1:34b1c6b81e3b9e290bd165bddb0c6ae31fea231e00a14b62558e8c9dd9babfef"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -505,32 +404,26 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace",
+    "trace"
   ]
-  pruneopts = "NUT"
   revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
 
 [[projects]]
   branch = "master"
-  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
-  pruneopts = "NUT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
-  digest = "1:5420733d35e5e562fffc7c5b99660f3587af042b5420f19b17fe0426e6a5259d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
-  digest = "1:0a6ace3c8a521f2c8861e89b8a22fc869c831e9bf6ad21fc62eb59afa16a8bff"
   name = "golang.org/x/text"
   packages = [
     "cases",
@@ -548,33 +441,27 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"
   name = "google.golang.org/appengine"
   packages = ["cloudsql"]
-  pruneopts = "NUT"
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:eff11a4ed88d9d3e28dd697961c550af1c4d0d3dccdc6252715b9a65a1d541bb"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
-    "googleapis/rpc/status",
+    "googleapis/rpc/status"
   ]
-  pruneopts = "NUT"
   revision = "e92b116572682a5b432ddd840aeaba2a559eeff1"
 
 [[projects]]
-  digest = "1:d0e5846da58e4e20d1bbd7502b24f31d37e3ac1e02a9042d95bd93c2d0c139dd"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -601,96 +488,39 @@
     "stats",
     "status",
     "tap",
-    "transport",
+    "transport"
   ]
-  pruneopts = "NUT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
 [[projects]]
-  digest = "1:cbc28d81cb78ef82f3ba643b97cd33f6c529353fb2f3bfbab463aec4504a2cc0"
   name = "gopkg.in/olivere/elastic.v5"
   packages = [
     ".",
     "config",
-    "uritemplates",
+    "uritemplates"
   ]
-  pruneopts = "NUT"
   revision = "52741dc2ce53629cbe1e673869040d886cba2cd5"
   version = "v5.0.70"
 
 [[projects]]
-  digest = "1:f3afbc73d5c6c35c71e6b763529db20270a71e028712b76e0f86c233eba3cd2f"
   name = "gopkg.in/sourcemap.v1"
   packages = [
     ".",
-    "base64vlq",
+    "base64vlq"
   ]
-  pruneopts = "NUT"
   revision = "6e83acea0053641eff084973fee085f0c193c61a"
   version = "v1.0.5"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/Shopify/sarama",
-    "github.com/augustoroman/v8",
-    "github.com/bmeg/golib",
-    "github.com/boltdb/bolt",
-    "github.com/dgraph-io/badger",
-    "github.com/dgraph-io/badger/options",
-    "github.com/dop251/goja",
-    "github.com/ghodss/yaml",
-    "github.com/globalsign/mgo",
-    "github.com/globalsign/mgo/bson",
-    "github.com/go-sql-driver/mysql",
-    "github.com/golang/gddo/httputil",
-    "github.com/golang/protobuf/jsonpb",
-    "github.com/golang/protobuf/proto",
-    "github.com/golang/protobuf/ptypes/struct",
-    "github.com/graphql-go/graphql",
-    "github.com/graphql-go/handler",
-    "github.com/grpc-ecosystem/go-grpc-middleware",
-    "github.com/grpc-ecosystem/go-grpc-middleware/retry",
-    "github.com/grpc-ecosystem/grpc-gateway/runtime",
-    "github.com/grpc-ecosystem/grpc-gateway/utilities",
-    "github.com/hashicorp/go-multierror",
-    "github.com/imdario/mergo",
-    "github.com/jmoiron/sqlx",
-    "github.com/knakk/rdf",
-    "github.com/kr/pretty",
-    "github.com/lib/pq",
-    "github.com/logrusorgru/aurora",
-    "github.com/oliveagle/jsonpath",
-    "github.com/robertkrimen/otto",
-    "github.com/segmentio/ksuid",
-    "github.com/sirupsen/logrus",
-    "github.com/spenczar/tdigest",
-    "github.com/spf13/cobra",
-    "github.com/stretchr/testify/assert",
-    "github.com/syndtr/goleveldb/leveldb",
-    "github.com/syndtr/goleveldb/leveldb/iterator",
-    "github.com/tecbot/gorocksdb",
-    "golang.org/x/crypto/ssh/terminal",
-    "golang.org/x/net/context",
-    "golang.org/x/sync/errgroup",
-    "google.golang.org/genproto/googleapis/api/annotations",
-    "google.golang.org/grpc",
-    "google.golang.org/grpc/codes",
-    "google.golang.org/grpc/grpclog",
-    "google.golang.org/grpc/metadata",
-    "google.golang.org/grpc/status",
-    "gopkg.in/olivere/elastic.v5",
-    "gopkg.in/yaml.v2",
-  ]
+  inputs-digest = "2b03efe7d8023a8c4cef68308408c9d9d5f2fb852f0ca7d31c62603dae95c13a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,41 +3,54 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:386e5a632be2aa525a327e13694bd22bde42fe6fe925c3bfef89b59c6e10b08f"
   name = "github.com/AndreasBriese/bbloom"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "28f7e881ca57bc00e028f9ede9f0d9104cfeef5e"
 
 [[projects]]
+  digest = "1:9c883d2e7fd391fbc7db7536863cc4cd181a97646b4659e9a7e7aa583c411885"
   name = "github.com/Shopify/sarama"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "35324cf48e33d8260e1c7c18854465a904ade249"
   version = "v1.17.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a0bcc2589c645af2393d9c567419b55b92738c68af2da39431859989e63bd289"
   name = "github.com/augustoroman/v8"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b371c0b05b97917d55880f2deaa0bc1262d04c0d"
 
 [[projects]]
   branch = "master"
+  digest = "1:8b5b2ef26f194968cadcac09ca84f1275057cca6461af79d1c2547964c634c81"
   name = "github.com/bmeg/golib"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "82a1e1d7a0b26093e4bcdc4522cbf93d9cd5f694"
 
 [[projects]]
+  digest = "1:a12d94258c5298ead75e142e8001224bf029f302fed9e96cd39c0eaf90f3954d"
   name = "github.com/boltdb/bolt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
   version = "v1.3.1"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:08ac19c58238c521ce132af2edfa64d75d209267a44ac83f5b23dff8a4381cfd"
   name = "github.com/dgraph-io/badger"
   packages = [
     ".",
@@ -45,99 +58,123 @@
     "protos",
     "skl",
     "table",
-    "y"
+    "y",
   ]
+  pruneopts = "NUT"
   revision = "a6f0866f06a0ef6ac612e427ffe5d081db4e6fab"
   version = "v1.5.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bde5c0379e801eefa31b42f0898745c298a25473ab62da93ac94d5da7e4196c"
   name = "github.com/dgryski/go-farm"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2de33835d10275975374b37b2dcfd22c9020a1f5"
 
 [[projects]]
+  digest = "1:e32db9fddc5e745860ca0f4176670d2cf839d3afa06b09ad595b8a99be8b5cb6"
   name = "github.com/dlclark/regexp2"
   packages = [
     ".",
-    "syntax"
+    "syntax",
   ]
+  pruneopts = "NUT"
   revision = "487489b64fb796de2e55f4e8a4ad1e145f80e957"
   version = "v1.1.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:9af09d68bd80a20b3fae068ab7c6476c9b53a145963b57df6d508180aabae7b9"
   name = "github.com/dop251/goja"
   packages = [
     ".",
     "ast",
     "file",
     "parser",
-    "token"
+    "token",
   ]
+  pruneopts = "NUT"
   revision = "9183045acc25574e0dd2ad37d5e7f978b1a4de12"
 
 [[projects]]
+  digest = "1:08143362be979b087c2c1bae5dde986e988d3d5d4dc661727cbe436411b3f33a"
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
+  pruneopts = "NUT"
   revision = "ea41b0fad31007accc7f806884dcdf3da98b79ce"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:033fde904d4c8ea10fba6c3895bea4ae5313f29c484b30146700a25fac62d640"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "040cc1a32f578808623071247fdbd5cc43f37f5f"
 
 [[projects]]
+  digest = "1:0d36a2b325b9e75f8057f7f9fbe778d348d70ba652cb9335485b69d1a5c4e038"
   name = "github.com/eapache/queue"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "44cc805cf13205b55f69e14bcb69867d1ae92f98"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6be8997d410d48dd045a8c18ee25e59ebfaeb9aa502c240b0d8ad9bb3e3fdd4f"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram"
+    "internal/scram",
   ]
+  pruneopts = "NUT"
   revision = "113d3961e7311526535a1ef7042196563d442761"
 
 [[projects]]
+  digest = "1:7d5c6757be75cd60d5936e26b2894c16bbb555bd8dad4724b0fa19efb3a6f78b"
   name = "github.com/go-sourcemap/sourcemap"
   packages = [
     ".",
-    "internal/base64vlq"
+    "internal/base64vlq",
   ]
+  pruneopts = "NUT"
   revision = "b019cc30c1eaa584753491b0d8f8c1534bf1eb44"
   version = "v2.1.2"
 
 [[projects]]
+  digest = "1:747c1fcb10f8f6734551465ab73c6ed9c551aa6e66250fb6683d1624f554546a"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d523deb1b23d913de5bdada721a6071e71283618"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8f251d09f52a8920bdba202b0c18a24cafb4f70f94b9afd8d02bf7643cfc99a0"
   name = "github.com/golang/gddo"
   packages = [
     "httputil",
-    "httputil/header"
+    "httputil/header",
   ]
+  pruneopts = "NUT"
   revision = "daffe1f90ec57f8ed69464f9094753fc6452e983"
 
 [[projects]]
+  digest = "1:6aef947ba53156da1a66ee891d70d61835e0dcfc9f0d728ae1132db651e81c22"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -147,18 +184,22 @@
     "ptypes/any",
     "ptypes/duration",
     "ptypes/struct",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:7f114b78210bf5b75f307fc97cff293633c835bab1e0ea8a744a44b39c042dfe"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  digest = "1:7ebd5fd1451351e650592acecee7eb05516fc319160ef4d2e42d773fe75046f3"
   name = "github.com/graphql-go/graphql"
   packages = [
     ".",
@@ -171,150 +212,190 @@
     "language/printer",
     "language/source",
     "language/typeInfo",
-    "language/visitor"
+    "language/visitor",
   ]
+  pruneopts = "NUT"
   revision = "1e23489041ba90a66f317fe0deccb236a2fff3cb"
   version = "v0.7.5"
 
 [[projects]]
+  digest = "1:eeae01d7aaaabdd5ab150793370f78e919e12640f8cc9a7824c6209cf64a178a"
   name = "github.com/graphql-go/handler"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "f0393b2c10daeebea900292b8e092e73475399d9"
   version = "v0.2.1"
 
 [[projects]]
+  digest = "1:607422aa5679ef904f4f28f394b5ca32b55f08dae4b887576902844d1310cddc"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
     "retry",
     "util/backoffutils",
-    "util/metautils"
+    "util/metautils",
   ]
+  pruneopts = "NUT"
   revision = "c250d6563d4d4c20252cd865923440e829844f4e"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:5c3363169fc963321cd0789dda2ddff90562817d277e78011b0e1bbf51a6b473"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
     "runtime",
     "runtime/internal",
-    "utilities"
+    "utilities",
   ]
+  pruneopts = "NUT"
   revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
   version = "v1.4.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0d9d74edbd40fdeada436d5ac9cb5197407899af3fef85ff0137077ffe8ae19"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
+  digest = "1:4d55897d00e9b53c1c716e8fe504de3d21bec8edba0a330bfaa87902695e46e2"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
+  digest = "1:65300ccc4bcb38b107b868155c303312978981e56bca707c81efec57575b5e06"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
+  digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f8670bc82b370c3dd4a64699bc7157cb66bb7c4f43be06edd5e7e4cc134bfa57"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
-    "reflectx"
+    "reflectx",
   ]
+  pruneopts = "NUT"
   revision = "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849"
 
 [[projects]]
   branch = "master"
+  digest = "1:29b28f180efcbaf57b5a5b91d9299a1f1fa749a8ab0a69fb9bcbf1f58b8749d3"
   name = "github.com/knakk/rdf"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b6ee24f8f40ff0580683aefb6831dad263a3f751"
 
 [[projects]]
+  digest = "1:7b21c7fc5551b46d1308b4ffa9e9e49b66c7a8b0ba88c0130474b0e7a20d859f"
   name = "github.com/kr/pretty"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:c3a7836b5904db0f8b609595b619916a6831cb35b8b714aec39f96d00c6155d8"
   name = "github.com/kr/text"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6415011db6d5f89961c38446f3552c74749462bef94904534c55e3dda1affeb9"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid"
+    "oid",
   ]
+  pruneopts = "NUT"
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
 
 [[projects]]
   branch = "master"
+  digest = "1:f2079ac1290c01101c5331fe60f824ae57dfeaf53e7174edeb368c2337468743"
   name = "github.com/logrusorgru/aurora"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d694e6f975a9109e2b063829d563a7c153c4b53c"
 
 [[projects]]
   branch = "master"
+  digest = "1:92b635b2786bcc08f53d2efc953ef32ef695e028aceb03d157ce2a6d468bec2a"
   name = "github.com/mailru/easyjson"
   packages = [
     ".",
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = "NUT"
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
   branch = "master"
+  digest = "1:a9c9c350ae298eb1cc8d92c7e18f39e2e816127ca540f96b5c9dc6f1ffbc05ab"
   name = "github.com/oliveagle/jsonpath"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2e52cf6e685269ed8aefec6390f3cac3ef74e730"
 
 [[projects]]
+  digest = "1:bf8b95442fa2d448bde39997d6fde56de40344b422d93cea4deead8de699e190"
   name = "github.com/pierrec/lz4"
   packages = [
     ".",
-    "internal/xxh32"
+    "internal/xxh32",
   ]
+  pruneopts = "NUT"
   revision = "1958fd8fff7f115e79725b1288e0b878b3e06b00"
   version = "v2.0.3"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:7c522337040d4ec9a136cd9d64fe4677ee1d3eae4a7f8831c2108f9bec43fa48"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   branch = "master"
+  digest = "1:122fdd61e136e89e520052921d535753b34853224de4f4d1482a3578d4fdb541"
   name = "github.com/robertkrimen/otto"
   packages = [
     ".",
@@ -323,48 +404,62 @@
     "file",
     "parser",
     "registry",
-    "token"
+    "token",
   ]
+  pruneopts = "NUT"
   revision = "15f95af6e78dcd2030d8195a138bd88d4f403546"
 
 [[projects]]
+  digest = "1:e131953e0822abeff314f8f7cc869e26dc799d4718aa967c7db120aeb28f58f9"
   name = "github.com/segmentio/ksuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "112f929a3020abfcd06b77c963ec919130796a35"
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:b2339e83ce9b5c4f79405f949429a7f68a9a904fed903c672aac1e7ceb7f5f02"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
+  digest = "1:20998b12ca59a28c75b02dedfe8eaf6e56d0f3cd38d796d6107ca344c1a7024d"
   name = "github.com/spenczar/tdigest"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c30a5bef6c2a91b32b7044b570024f0faf39c959"
   version = "v2.1.0"
 
 [[projects]]
+  digest = "1:343d44e06621142ab09ae0c76c1799104cdfddd3ffb445d78b1adf8dc3ffaf3d"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
 
 [[projects]]
+  digest = "1:bacb8b590716ab7c33f2277240972c9582d389593ee8d66fc10074e0508b8126"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "NUT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:b3cfb8d82b1601a846417c3f31c03a7961862cb2c98dcf0959c473843e6d9a2b"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -378,24 +473,30 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util"
+    "leveldb/util",
   ]
+  pruneopts = "NUT"
   revision = "c4c61651e9e37fa117f53c5a906d3b63090d8445"
 
 [[projects]]
   branch = "master"
+  digest = "1:2b78b2e3d2ed94b7dbdc5dc7916dbdb4211112dd11d90f753dc5a45b8dabb7ac"
   name = "github.com/tecbot/gorocksdb"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3e476152774442234f9a9f747386a48a1d82a515"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "NUT"
   revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [[projects]]
   branch = "master"
+  digest = "1:34b1c6b81e3b9e290bd165bddb0c6ae31fea231e00a14b62558e8c9dd9babfef"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -404,26 +505,32 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "NUT"
   revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
 
 [[projects]]
   branch = "master"
+  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
+  pruneopts = "NUT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:5420733d35e5e562fffc7c5b99660f3587af042b5420f19b17fe0426e6a5259d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NUT"
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
+  digest = "1:0a6ace3c8a521f2c8861e89b8a22fc869c831e9bf6ad21fc62eb59afa16a8bff"
   name = "golang.org/x/text"
   packages = [
     "cases",
@@ -441,27 +548,33 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"
   name = "google.golang.org/appengine"
   packages = ["cloudsql"]
+  pruneopts = "NUT"
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:eff11a4ed88d9d3e28dd697961c550af1c4d0d3dccdc6252715b9a65a1d541bb"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
-    "googleapis/rpc/status"
+    "googleapis/rpc/status",
   ]
+  pruneopts = "NUT"
   revision = "e92b116572682a5b432ddd840aeaba2a559eeff1"
 
 [[projects]]
+  digest = "1:d0e5846da58e4e20d1bbd7502b24f31d37e3ac1e02a9042d95bd93c2d0c139dd"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -488,39 +601,96 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "NUT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
 [[projects]]
+  digest = "1:cbc28d81cb78ef82f3ba643b97cd33f6c529353fb2f3bfbab463aec4504a2cc0"
   name = "gopkg.in/olivere/elastic.v5"
   packages = [
     ".",
     "config",
-    "uritemplates"
+    "uritemplates",
   ]
+  pruneopts = "NUT"
   revision = "52741dc2ce53629cbe1e673869040d886cba2cd5"
   version = "v5.0.70"
 
 [[projects]]
+  digest = "1:f3afbc73d5c6c35c71e6b763529db20270a71e028712b76e0f86c233eba3cd2f"
   name = "gopkg.in/sourcemap.v1"
   packages = [
     ".",
-    "base64vlq"
+    "base64vlq",
   ]
+  pruneopts = "NUT"
   revision = "6e83acea0053641eff084973fee085f0c193c61a"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2b03efe7d8023a8c4cef68308408c9d9d5f2fb852f0ca7d31c62603dae95c13a"
+  input-imports = [
+    "github.com/Shopify/sarama",
+    "github.com/augustoroman/v8",
+    "github.com/bmeg/golib",
+    "github.com/boltdb/bolt",
+    "github.com/dgraph-io/badger",
+    "github.com/dgraph-io/badger/options",
+    "github.com/dop251/goja",
+    "github.com/ghodss/yaml",
+    "github.com/globalsign/mgo",
+    "github.com/globalsign/mgo/bson",
+    "github.com/go-sql-driver/mysql",
+    "github.com/golang/gddo/httputil",
+    "github.com/golang/protobuf/jsonpb",
+    "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/ptypes/struct",
+    "github.com/graphql-go/graphql",
+    "github.com/graphql-go/handler",
+    "github.com/grpc-ecosystem/go-grpc-middleware",
+    "github.com/grpc-ecosystem/go-grpc-middleware/retry",
+    "github.com/grpc-ecosystem/grpc-gateway/runtime",
+    "github.com/grpc-ecosystem/grpc-gateway/utilities",
+    "github.com/hashicorp/go-multierror",
+    "github.com/imdario/mergo",
+    "github.com/jmoiron/sqlx",
+    "github.com/knakk/rdf",
+    "github.com/kr/pretty",
+    "github.com/lib/pq",
+    "github.com/logrusorgru/aurora",
+    "github.com/oliveagle/jsonpath",
+    "github.com/robertkrimen/otto",
+    "github.com/segmentio/ksuid",
+    "github.com/sirupsen/logrus",
+    "github.com/spenczar/tdigest",
+    "github.com/spf13/cobra",
+    "github.com/stretchr/testify/assert",
+    "github.com/syndtr/goleveldb/leveldb",
+    "github.com/syndtr/goleveldb/leveldb/iterator",
+    "github.com/tecbot/gorocksdb",
+    "golang.org/x/crypto/ssh/terminal",
+    "golang.org/x/net/context",
+    "golang.org/x/sync/errgroup",
+    "google.golang.org/genproto/googleapis/api/annotations",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/grpclog",
+    "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/status",
+    "gopkg.in/olivere/elastic.v5",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/kvgraph/index.go
+++ b/kvgraph/index.go
@@ -85,7 +85,7 @@ func (kgdb *KVInterfaceGDB) VertexLabelScan(ctx context.Context, label string) c
 	go func() {
 		defer close(out)
 		//log.Printf("Searching %s %s", fmt.Sprintf("%s.label", kgdb.graph), label)
-		for i := range kgdb.kvg.idx.GetTermMatch(fmt.Sprintf("%s.label", kgdb.graph), label) {
+		for i := range kgdb.kvg.idx.GetTermMatch(ctx, fmt.Sprintf("%s.label", kgdb.graph), label) {
 			//log.Printf("Found: %s", i)
 			out <- i
 		}

--- a/kvgraph/test/index_test.go
+++ b/kvgraph/test/index_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"context"
+
 	"github.com/bmeg/grip/kvindex"
 )
 
@@ -86,7 +88,7 @@ func TestLoadDoc(t *testing.T) {
 	}
 
 	count := 0
-	for d := range idx.GetTermMatch("v.label", "Person") {
+	for d := range idx.GetTermMatch(context.Background(), "v.label", "Person") {
 		if !contains(personDocs, d) {
 			t.Errorf("Bad doc return: %s", d)
 		}
@@ -97,7 +99,7 @@ func TestLoadDoc(t *testing.T) {
 	}
 
 	count = 0
-	for d := range idx.GetTermMatch("v.data.firstName", "Bob") {
+	for d := range idx.GetTermMatch(context.Background(), "v.data.firstName", "Bob") {
 		if !contains(bobDocs, d) {
 			t.Errorf("Bad doc return: %s", d)
 		}
@@ -253,7 +255,7 @@ func TestDocDelete(t *testing.T) {
 	}
 
 	count = 0
-	for range idx.GetTermMatch("v.data.firstName", "Bob") {
+	for range idx.GetTermMatch(context.Background(), "v.data.firstName", "Bob") {
 		count++
 	}
 	if count != 0 {

--- a/server/api.go
+++ b/server/api.go
@@ -26,23 +26,28 @@ func (server *GripServer) Traversal(query *gripql.GraphQuery, queryServer gripql
 		return err
 	}
 	res := engine.Run(queryServer.Context(), pipeline, server.conf.WorkDir)
+	err = nil
 	for row := range res {
-		err := queryServer.Send(row)
-		if err != nil {
-			return fmt.Errorf("error sending Traversal result: %v", err)
+		if err == nil {
+			err = queryServer.Send(row)
 		}
 	}
-
+	if err != nil {
+		return fmt.Errorf("error sending Traversal result: %v", err)
+	}
 	return nil
 }
 
 // ListGraphs returns a list of graphs managed by the driver
 func (server *GripServer) ListGraphs(empty *gripql.Empty, queryServer gripql.Query_ListGraphsServer) error {
+	var err error
 	for _, name := range server.db.ListGraphs() {
-		err := queryServer.Send(&gripql.GraphID{Graph: name})
-		if err != nil {
-			return fmt.Errorf("error sending ListGraphs result: %v", err)
+		if err == nil {
+			err = queryServer.Send(&gripql.GraphID{Graph: name})
 		}
+	}
+	if err != nil {
+		return fmt.Errorf("error sending ListGraphs result: %v", err)
 	}
 	return nil
 }
@@ -362,10 +367,12 @@ func (server *GripServer) ListIndices(idx *gripql.GraphID, stream gripql.Query_L
 	}
 	res := graph.GetVertexIndexList()
 	for i := range res {
-		err := stream.Send(&i)
-		if err != nil {
-			return fmt.Errorf("error sending ListIndices result: %v", err)
+		if err == nil {
+			err = stream.Send(&i)
 		}
+	}
+	if err != nil {
+		return fmt.Errorf("error sending ListIndices result: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
For GRPC client, if a transport error is encountered, continue to read the traversal channel so search functions don't get locked on send channels.
This should fix #156 