### PR TITLE
cmd/schema/sample: avoid expensive lookups

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -99,7 +99,7 @@ var postCmd = &cobra.Command{
 }
 
 var sampleCmd = &cobra.Command{
-	Use:   "sample",
+	Use:   "sample <graph>",
 	Short: "Sample graph and construct schema",
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),

--- a/gripql/query.go
+++ b/gripql/query.go
@@ -183,7 +183,7 @@ func (q *Query) Count() *Query {
 }
 
 // Distinct selects records with distinct elements of arg
-func (q *Query) Distinct(args []string) *Query {
+func (q *Query) Distinct(args ...string) *Query {
 	return q.with(&GraphStatement{Statement: &GraphStatement_Distinct{protoutil.AsListValue(args)}})
 }
 


### PR DESCRIPTION
Known issues:
- possible to miss some edge from/to combos when edges are polymorphic
- edge schema lookup will fail for edges that reference vertices that don't exist