### PR TITLE
address oom issues

### DIFF
--- a/mongo/graph.go
+++ b/mongo/graph.go
@@ -116,8 +116,63 @@ func (mg *Graph) AddEdge(edges []*gdbi.Edge) error {
 	return err
 }
 
+func (mg *Graph) StreamEdges(edgeChan <-chan *gdbi.Edge, batchsize int) error {
+	eCol := mg.ar.EdgeCollection(mg.graph)
+	var err error
+	docBatch := make([]mongo.WriteModel, 0, batchsize)
+
+	for edge := range edgeChan {
+		i := mongo.NewReplaceOneModel().SetUpsert(true).SetFilter(bson.M{FIELD_ID: edge.ID})
+		ent := PackEdge(edge)
+		i.SetReplacement(ent)
+		docBatch = append(docBatch, i)
+
+		if len(docBatch) >= batchsize {
+			_, err = eCol.BulkWrite(context.Background(), docBatch)
+			if err != nil {
+				log.Errorf("StreamEdges error: (%s) %s", docBatch, err)
+			}
+			docBatch = docBatch[:0]
+		}
+	}
+	if len(docBatch) > 0 {
+		_, err = eCol.BulkWrite(context.Background(), docBatch)
+		if err != nil {
+			log.Errorf("StreamEdges error: (%s) %s", docBatch, err)
+		}
+	}
+	return err
+}
+
+func (mg *Graph) StreamVertices(vertChan <-chan *gdbi.Vertex, batchsize int) error {
+	vCol := mg.ar.VertexCollection(mg.graph)
+	var err error
+	docBatch := make([]mongo.WriteModel, 0, batchsize)
+	for v := range vertChan {
+		i := mongo.NewReplaceOneModel().SetUpsert(true).SetFilter(bson.M{FIELD_ID: v.ID})
+		ent := PackVertex(v)
+		i.SetReplacement(ent)
+		docBatch = append(docBatch, i)
+
+		if len(docBatch) >= batchsize {
+			_, err = vCol.BulkWrite(context.Background(), docBatch)
+			if err != nil {
+				log.Errorf("StreamVertices error: (%s) %s", docBatch, err)
+			}
+			docBatch = docBatch[:0]
+		}
+	}
+	if len(docBatch) > 0 {
+		_, err = vCol.BulkWrite(context.Background(), docBatch)
+		if err != nil {
+			log.Errorf("StreamVertices error: (%s) %s", docBatch, err)
+		}
+	}
+	return err
+}
+
 func (mg *Graph) BulkAdd(stream <-chan *gdbi.GraphElement) error {
-	return util.StreamBatch(stream, 50, mg.graph, mg.AddVertex, mg.AddEdge)
+	return util.StreamBatch(stream, 100, mg.graph, mg.StreamVertices, mg.StreamEdges)
 }
 
 func (mg *Graph) BulkDel(Data *gdbi.DeleteData) error {

--- a/mongo/graph.go
+++ b/mongo/graph.go
@@ -132,7 +132,7 @@ func (mg *Graph) StreamEdges(edgeChan <-chan *gdbi.Edge, batchsize int) error {
 			if err != nil {
 				log.Errorf("StreamEdges error: (%s) %s", docBatch, err)
 			}
-			docBatch = docBatch[:0]
+			docBatch = make([]mongo.WriteModel, 0, batchsize)
 		}
 	}
 	if len(docBatch) > 0 {
@@ -159,7 +159,7 @@ func (mg *Graph) StreamVertices(vertChan <-chan *gdbi.Vertex, batchsize int) err
 			if err != nil {
 				log.Errorf("StreamVertices error: (%s) %s", docBatch, err)
 			}
-			docBatch = docBatch[:0]
+			docBatch = make([]mongo.WriteModel, 0, batchsize)
 		}
 	}
 	if len(docBatch) > 0 {
@@ -172,7 +172,7 @@ func (mg *Graph) StreamVertices(vertChan <-chan *gdbi.Vertex, batchsize int) err
 }
 
 func (mg *Graph) BulkAdd(stream <-chan *gdbi.GraphElement) error {
-	return util.StreamBatch(stream, 100, mg.graph, mg.StreamVertices, mg.StreamEdges)
+	return util.StreamBatch(stream, 50, mg.graph, mg.StreamVertices, mg.StreamEdges)
 }
 
 func (mg *Graph) BulkDel(Data *gdbi.DeleteData) error {

--- a/mongo/graph.go
+++ b/mongo/graph.go
@@ -172,7 +172,7 @@ func (mg *Graph) StreamVertices(vertChan <-chan *gdbi.Vertex, batchsize int) err
 }
 
 func (mg *Graph) BulkAdd(stream <-chan *gdbi.GraphElement) error {
-	return util.StreamBatch(stream, 50, mg.graph, mg.StreamVertices, mg.StreamEdges)
+	return util.StreamBatch(stream, 100, mg.graph, mg.StreamVertices, mg.StreamEdges)
 }
 
 func (mg *Graph) BulkDel(Data *gdbi.DeleteData) error {

--- a/psql/graph.go
+++ b/psql/graph.go
@@ -99,7 +99,6 @@ func (g *Graph) StreamVertices(vertices <-chan *gdbi.Vertex, workers int) error 
 		return fmt.Errorf("StreamVertices: Prepare Stmt: %v", err)
 	}
 
-	count := 0
 	for v := range vertices {
 		js, err := json.Marshal(v.Data)
 		if err != nil {
@@ -109,24 +108,6 @@ func (g *Graph) StreamVertices(vertices <-chan *gdbi.Vertex, workers int) error 
 		if err != nil {
 			return fmt.Errorf("StreamVertices: Stmt.Exec: %v", err)
 		}
-		count++
-
-		if count%1000 == 0 {
-			if err := txn.Commit(); err != nil {
-				_ = stmt.Close()
-				return fmt.Errorf("StreamVertices: Txn.Commit: %v", err)
-			}
-
-			txn, err = g.db.Begin()
-			if err != nil {
-				return fmt.Errorf("StreamVertices: Begin New Txn: %v", err)
-			}
-			stmt, err = txn.Prepare(s)
-			if err != nil {
-				return fmt.Errorf("StreamVertices: Prepare New Stmt: %v", err)
-			}
-		}
-
 	}
 
 	err = stmt.Close()
@@ -154,8 +135,8 @@ func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
 		ON CONFLICT (gid) DO UPDATE SET
 		gid = excluded.gid,
 		label = excluded.label,
-		"from" = excluded.from,
-		"to" = excluded.to,
+		"from" = excluded."from",
+		"to" = excluded."to",
 		data = excluded.data;`,
 		g.e,
 	)
@@ -164,7 +145,6 @@ func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
 		return fmt.Errorf("StreamEdges: Prepare Stmt: %v", err)
 	}
 
-	count := 0
 	for e := range edges {
 		js, err := json.Marshal(e.Data)
 		if err != nil {
@@ -174,28 +154,11 @@ func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
 		if err != nil {
 			return fmt.Errorf("AddEdge: Stmt.Exec: %v", err)
 		}
-		count++
-		if count%1000 == 0 {
-			if err := txn.Commit(); err != nil {
-				_ = stmt.Close()
-				return fmt.Errorf("StreamEdges: Txn.Commit: %v", err)
-			}
-
-			txn, err = g.db.Begin()
-			if err != nil {
-				return fmt.Errorf("StreamEdges: Begin New Txn: %v", err)
-			}
-			stmt, err = txn.Prepare(s)
-			if err != nil {
-				return fmt.Errorf("StreamEdges: Prepare New Stmt: %v", err)
-			}
-		}
-
 	}
 
 	err = stmt.Close()
 	if err != nil {
-		return fmt.Errorf("StreamEdges: Stmt.Close: %v", err)
+		return fmt.Errorf("StreamVertices: Stmt.Close: %v", err)
 	}
 
 	err = txn.Commit()

--- a/psql/graph.go
+++ b/psql/graph.go
@@ -79,6 +79,133 @@ func (g *Graph) AddVertex(vertices []*gdbi.Vertex) error {
 	return nil
 }
 
+// AddVertex adds a vertex to the database
+func (g *Graph) StreamVertices(vertices <-chan *gdbi.Vertex, workers int) error {
+	txn, err := g.db.Begin()
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Begin Txn: %v", err)
+	}
+
+	s := fmt.Sprintf(
+		`INSERT INTO %s (gid, label, data) VALUES ($1, $2, $3)
+		 ON CONFLICT (gid) DO UPDATE SET
+		 gid = excluded.gid,
+		 label = excluded.label,
+		 data = excluded.data;`,
+		g.v,
+	)
+	stmt, err := txn.Prepare(s)
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Prepare Stmt: %v", err)
+	}
+
+	count := 0
+	for v := range vertices {
+		js, err := json.Marshal(v.Data)
+		if err != nil {
+			return fmt.Errorf("StreamVertices: Stmt.Exec: %v", err)
+		}
+		_, err = stmt.Exec(v.ID, v.Label, js)
+		if err != nil {
+			return fmt.Errorf("StreamVertices: Stmt.Exec: %v", err)
+		}
+		count++
+
+		if count%1000 == 0 {
+			if err := txn.Commit(); err != nil {
+				_ = stmt.Close()
+				return fmt.Errorf("StreamVertices: Txn.Commit: %v", err)
+			}
+
+			txn, err = g.db.Begin()
+			if err != nil {
+				return fmt.Errorf("StreamVertices: Begin New Txn: %v", err)
+			}
+			stmt, err = txn.Prepare(s)
+			if err != nil {
+				return fmt.Errorf("StreamVertices: Prepare New Stmt: %v", err)
+			}
+		}
+
+	}
+
+	err = stmt.Close()
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Stmt.Close: %v", err)
+	}
+
+	err = txn.Commit()
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Txn.Commit: %v", err)
+	}
+
+	return nil
+}
+
+// AddEdge adds an edge to the database
+func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
+	txn, err := g.db.Begin()
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Begin Txn: %v", err)
+	}
+
+	s := fmt.Sprintf(
+		`INSERT INTO %s (gid, label, "from", "to", data) VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (gid) DO UPDATE SET
+		gid = excluded.gid,
+		label = excluded.label,
+		"from" = excluded.from,
+		"to" = excluded.to,
+		data = excluded.data;`,
+		g.e,
+	)
+	stmt, err := txn.Prepare(s)
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Prepare Stmt: %v", err)
+	}
+
+	count := 0
+	for e := range edges {
+		js, err := json.Marshal(e.Data)
+		if err != nil {
+			return fmt.Errorf("AddEdge: Stmt.Exec: %v", err)
+		}
+		_, err = stmt.Exec(e.ID, e.Label, e.From, e.To, js)
+		if err != nil {
+			return fmt.Errorf("AddEdge: Stmt.Exec: %v", err)
+		}
+		count++
+		if count%1000 == 0 {
+			if err := txn.Commit(); err != nil {
+				_ = stmt.Close()
+				return fmt.Errorf("StreamEdges: Txn.Commit: %v", err)
+			}
+
+			txn, err = g.db.Begin()
+			if err != nil {
+				return fmt.Errorf("StreamEdges: Begin New Txn: %v", err)
+			}
+			stmt, err = txn.Prepare(s)
+			if err != nil {
+				return fmt.Errorf("StreamEdges: Prepare New Stmt: %v", err)
+			}
+		}
+
+	}
+
+	err = stmt.Close()
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Stmt.Close: %v", err)
+	}
+
+	err = txn.Commit()
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Txn.Commit: %v", err)
+	}
+
+	return nil
+}
+
 // AddEdge adds an edge to the database
 func (g *Graph) AddEdge(edges []*gdbi.Edge) error {
 	txn, err := g.db.Begin()
@@ -126,7 +253,7 @@ func (g *Graph) AddEdge(edges []*gdbi.Edge) error {
 }
 
 func (g *Graph) BulkAdd(stream <-chan *gdbi.GraphElement) error {
-	return util.StreamBatch(stream, 50, g.graph, g.AddVertex, g.AddEdge)
+	return util.StreamBatch(stream, 50, g.graph, g.StreamVertices, g.StreamEdges)
 }
 
 func (g *Graph) BulkDel(Data *gdbi.DeleteData) error {

--- a/server/api.go
+++ b/server/api.go
@@ -229,7 +229,7 @@ func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error 
 	var populated bool
 	var sch *gripql.Graph
 	out := &graph.GraphSchema{Classes: map[string]*jsonschema.Schema{}, Compiler: nil}
-	elementStream := make(chan *gdbi.GraphElement)
+	elementStream := make(chan *gdbi.GraphElement, 100)
 	var retErrs []string
 	for {
 		var err error
@@ -271,6 +271,11 @@ func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				for ge := range elementStream {
+					server.streamPool.Put(ge)
+				}
+			}()
 			err := graph.BulkAdd(elementStream)
 			if err != nil {
 				log.WithFields(log.Fields{"graph": class.Graph, "error": err}).Error("BulkAddRaw: error")
@@ -298,27 +303,24 @@ func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error 
 		}
 
 		for _, element := range result {
+			ge := server.streamPool.Get().(*gdbi.GraphElement)
+			ge.Graph = class.Graph
 			if element.Vertex != nil {
-				elementStream <- &gdbi.GraphElement{
-					Vertex: &gdbi.Vertex{
-						ID:    element.Vertex.Gid,
-						Data:  element.Vertex.Data.AsMap(),
-						Label: element.Vertex.Label,
-					},
-					Graph: class.Graph,
+				ge.Vertex = &gdbi.Vertex{
+					ID:    element.Vertex.Gid,
+					Data:  element.Vertex.Data.AsMap(),
+					Label: element.Vertex.Label,
 				}
 			} else {
-				elementStream <- &gdbi.GraphElement{
-					Edge: &gdbi.Edge{
-						ID:    element.Edge.Gid,
-						Label: element.Edge.Label,
-						From:  element.Edge.From,
-						To:    element.Edge.To,
-						Data:  element.Edge.Data.AsMap(),
-					},
-					Graph: class.Graph,
+				ge.Edge = &gdbi.Edge{
+					ID:    element.Edge.Gid,
+					Label: element.Edge.Label,
+					From:  element.Edge.From,
+					To:    element.Edge.To,
+					Data:  element.Edge.Data.AsMap(),
 				}
 			}
+			elementStream <- ge
 			insertCount++
 		}
 
@@ -410,6 +412,7 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 			} else {
 				insertCount++
 				elementStream <- gdbi.NewGraphElement(element)
+
 			}
 		}
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -231,6 +231,7 @@ func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error 
 	out := &graph.GraphSchema{Classes: map[string]*jsonschema.Schema{}, Compiler: nil}
 	elementStream := make(chan *gdbi.GraphElement, 100)
 	var retErrs []string
+	sem := make(chan struct{}, 1000)
 	for {
 		var err error
 		class, err := stream.Recv()
@@ -320,13 +321,16 @@ func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error 
 					Data:  element.Edge.Data.AsMap(),
 				}
 			}
+			sem <- struct{}{}
 			elementStream <- ge
 			insertCount++
+			<-sem
 		}
 
 	}
 	close(elementStream)
 	wg.Wait()
+	close(sem)
 	return stream.SendAndClose(&gripql.BulkJsonEditResult{InsertCount: insertCount, Errors: retErrs})
 }
 

--- a/server/api.go
+++ b/server/api.go
@@ -224,131 +224,168 @@ func (server *GripServer) addEdge(ctx context.Context, elem *gripql.GraphElement
 }
 
 func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error {
-	var insertCount int32
-	wg := &sync.WaitGroup{}
-	var populated bool
-	var sch *gripql.Graph
-	out := &graph.GraphSchema{Classes: map[string]*jsonschema.Schema{}, Compiler: nil}
-	elementStream := make(chan *gdbi.GraphElement, 50)
+	elementStream := make(chan *gdbi.GraphElement, 100)
 	var retErrs []string
-	sem := make(chan struct{}, 100)
-	for {
-		var err error
-		class, err := stream.Recv()
-		if err == io.EOF {
-			break
-		}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var insertCount int32 = 0
 
+	// Receive first message
+	firstClass, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	gdb, err := server.getGraphDB(firstClass.Graph)
+	if err != nil {
+		return err
+	}
+
+	graphtwo, err := gdb.Graph(firstClass.Graph)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err}).Error("BulkAddRaw: error")
+		return err
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := graphtwo.BulkAdd(elementStream)
+		if err != nil {
+			log.WithFields(log.Fields{"graph": firstClass.Graph, "error": err}).Error("BulkAddRaw: error")
+			mu.Lock()
+			retErrs = append(retErrs, err.Error())
+			mu.Unlock()
+		}
+	}()
+
+	// Process schema and stream
+	var populated bool
+	out := &graph.GraphSchema{Classes: map[string]*jsonschema.Schema{}, Compiler: nil}
+
+	processClass := func(class *gripql.RawJson) {
 		if !populated {
-			sch, err = server.getGraph(class.Graph + "__schema__")
+			sch, err := server.getGraph(class.Graph + "__schema__")
 			if err != nil {
 				log.Errorf("Error loading schemas: %v", err)
+				mu.Lock()
 				retErrs = append(retErrs, err.Error())
-				break
+				mu.Unlock()
+				return
 			}
 
+			mu.Lock()
 			out, err = server.LoadSchemas(sch, out)
+			mu.Unlock()
+
 			if err != nil {
 				log.Errorf("Error loading schemas: %v", err)
+				mu.Lock()
 				retErrs = append(retErrs, err.Error())
-				break
+				mu.Unlock()
+				return
 			}
 			populated = true
 		}
 
-		gdb, err := server.getGraphDB(class.Graph)
-		if err != nil {
-			retErrs = append(retErrs, err.Error())
-			break
-		}
-
-		graph, err := gdb.Graph(class.Graph)
-		if err != nil {
-			log.WithFields(log.Fields{"error": err}).Error("BulkAddRaw: error")
-			retErrs = append(retErrs, err.Error())
-			continue
-		}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer func() {
-				for ge := range elementStream {
-					server.streamPool.Put(ge)
-				}
-			}()
-			err := graph.BulkAdd(elementStream)
-			if err != nil {
-				log.WithFields(log.Fields{"graph": class.Graph, "error": err}).Error("BulkAddRaw: error")
-				retErrs = append(retErrs, err.Error())
-			}
-		}()
-
 		classData := class.Data.AsMap()
-
-		// to generate grip data, need to know what type the data is.
 		resourceType, ok := classData["resourceType"].(string)
 		if !ok {
 			log.WithFields(log.Fields{"error": fmt.Errorf("row %s does not have required field resourceType", classData)}).Error("BulkAddRaw: streaming error")
+			mu.Lock()
 			retErrs = append(retErrs, fmt.Sprintf("row %s does not have required field resourceType", classData))
-			continue
+			mu.Unlock()
+			return
 		}
 
-		args := class.ExtraArgs.AsMap()
+		result, err := out.Generate(resourceType, classData, false, class.ExtraArgs.AsMap())
 
-		result, err := out.Generate(resourceType, classData, false, args)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Errorf("BulkAddRaw: validation error for %s: %s", resourceType, classData)
+			mu.Lock()
 			retErrs = append(retErrs, err.Error())
-			continue
+			mu.Unlock()
+			return
 		}
 
 		for _, element := range result {
-			ge := server.streamPool.Get().(*gdbi.GraphElement)
-			ge.Graph = class.Graph
 			if element.Vertex != nil {
-				ge.Vertex = &gdbi.Vertex{
-					ID:    element.Vertex.Gid,
-					Data:  element.Vertex.Data.AsMap(),
-					Label: element.Vertex.Label,
-				}
+				elementStream <- &gdbi.GraphElement{
+					Vertex: &gdbi.Vertex{
+						ID:    element.Vertex.Gid,
+						Data:  element.Vertex.Data.AsMap(),
+						Label: element.Vertex.Label,
+					},
+					Graph: class.Graph}
 			} else {
-				ge.Edge = &gdbi.Edge{
-					ID:    element.Edge.Gid,
-					Label: element.Edge.Label,
-					From:  element.Edge.From,
-					To:    element.Edge.To,
-					Data:  element.Edge.Data.AsMap(),
-				}
+				elementStream <- &gdbi.GraphElement{
+					Edge: &gdbi.Edge{
+						ID:    element.Edge.Gid,
+						Label: element.Edge.Label,
+						From:  element.Edge.From,
+						To:    element.Edge.To,
+						Data:  element.Edge.Data.AsMap(),
+					},
+					Graph: class.Graph}
 			}
-			sem <- struct{}{}
-			elementStream <- ge
+			mu.Lock()
 			insertCount++
-			<-sem
+			mu.Unlock()
 		}
-
 	}
-	close(elementStream)
+
+	processClass(firstClass)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(elementStream)
+
+		for {
+			class, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				mu.Lock()
+				retErrs = append(retErrs, err.Error())
+				mu.Unlock()
+				break
+			}
+			processClass(class)
+		}
+	}()
+
 	wg.Wait()
-	close(sem)
+
 	return stream.SendAndClose(&gripql.BulkJsonEditResult{InsertCount: insertCount, Errors: retErrs})
 }
 
-// BulkAdd a stream of inputs and loads them into the graph
 func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
-	var graphName string
 	var insertCount int32
 	var errorCount int32
+	var mu sync.Mutex
 
-	elementStream := make(chan *gdbi.GraphElement, 50)
 	wg := &sync.WaitGroup{}
+	currentGraph := ""
+	var elementStream chan *gdbi.GraphElement
 
-	defer func() {
-		if elementStream != nil {
-			close(elementStream)
-		}
-		wg.Wait()
-	}()
+	// Function to start a new BulkAdd goroutine for a graph
+	startBulkAdd := func(graphName string, gdb gdbi.GraphInterface) chan *gdbi.GraphElement {
+		newStream := make(chan *gdbi.GraphElement, 100)
+		wg.Add(1)
+		go func(g gdbi.GraphInterface, stream chan *gdbi.GraphElement) {
+			defer wg.Done()
+			log.WithFields(log.Fields{"graph": graphName}).Info("BulkAdd: streaming elements to graph")
+			if err := g.BulkAdd(stream); err != nil {
+				log.WithFields(log.Fields{"graph": graphName, "error": err}).Error("BulkAdd: error")
+				mu.Lock()
+				errorCount++
+				mu.Unlock()
+			}
+		}(gdb, newStream)
+		return newStream
+	}
 
 	for {
 		element, err := stream.Recv()
@@ -357,57 +394,54 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 		}
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Error("BulkAdd: streaming error")
+			mu.Lock()
 			errorCount++
+			mu.Unlock()
 			break
 		}
 
 		if isSchema(element.Graph) {
 			err := "cannot add element to schema graph"
 			log.WithFields(log.Fields{"error": err}).Error("BulkAdd: error")
+			mu.Lock()
 			errorCount++
+			mu.Unlock()
 			continue
 		}
 
-		// create a BulkAdd stream per graph
-		// close and switch when a new graph is encountered
-		if element.Graph != graphName {
+		// Switch graphs if needed
+		if element.Graph != currentGraph {
 			if elementStream != nil {
 				close(elementStream)
-				wg.Wait()
 			}
+
 			gdb, err := server.getGraphDB(element.Graph)
 			if err != nil {
+				mu.Lock()
 				errorCount++
+				mu.Unlock()
 				continue
 			}
 
 			graph, err := gdb.Graph(element.Graph)
 			if err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("BulkAdd: error")
+				mu.Lock()
 				errorCount++
+				mu.Unlock()
 				continue
 			}
 
-			graphName = element.Graph
-			elementStream = make(chan *gdbi.GraphElement, 50)
-
-			wg.Add(1)
-			go func(graphName string, stream chan *gdbi.GraphElement) {
-				log.WithFields(log.Fields{"graph": element.Graph}).Info("BulkAdd: streaming elements to graph")
-				err := graph.BulkAdd(elementStream)
-				if err != nil {
-					log.WithFields(log.Fields{"graph": element.Graph, "error": err}).Error("BulkAdd: error")
-					// not a good representation of the true number of errors
-					errorCount++
-				}
-				wg.Done()
-			}(graphName, elementStream)
+			currentGraph = element.Graph
+			elementStream = startBulkAdd(currentGraph, graph)
 		}
 
+		// Process vertices
 		if element.Vertex != nil {
-			err := element.Vertex.Validate()
-			if err != nil {
+			if err := element.Vertex.Validate(); err != nil {
+				mu.Lock()
 				errorCount++
+				mu.Unlock()
 				log.WithFields(log.Fields{"graph": element.Graph, "error": err}).Errorf("BulkAdd: vertex validation failed for vertex: %#v", element.Vertex)
 			} else {
 				insertCount++
@@ -415,21 +449,28 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 			}
 		}
 
+		// Process edges
 		if element.Edge != nil {
 			if element.Edge.Gid == "" {
 				element.Edge.Gid = util.UUID()
 			}
-			err := element.Edge.Validate()
-			if err != nil {
+			if err := element.Edge.Validate(); err != nil {
+				mu.Lock()
 				errorCount++
+				mu.Unlock()
 				log.WithFields(log.Fields{"graph": element.Graph, "error": err}).Errorf("BulkAdd: edge validation failed for edge: %#v", element.Edge)
 			} else {
 				insertCount++
 				elementStream <- gdbi.NewGraphElement(element)
-
 			}
 		}
 	}
+
+	if elementStream != nil {
+		close(elementStream)
+	}
+
+	wg.Wait()
 
 	return stream.SendAndClose(&gripql.BulkEditResult{InsertCount: insertCount, ErrorCount: errorCount})
 }

--- a/server/api.go
+++ b/server/api.go
@@ -229,9 +229,9 @@ func (server *GripServer) BulkAddRaw(stream gripql.Edit_BulkAddRawServer) error 
 	var populated bool
 	var sch *gripql.Graph
 	out := &graph.GraphSchema{Classes: map[string]*jsonschema.Schema{}, Compiler: nil}
-	elementStream := make(chan *gdbi.GraphElement, 100)
+	elementStream := make(chan *gdbi.GraphElement, 50)
 	var retErrs []string
-	sem := make(chan struct{}, 1000)
+	sem := make(chan struct{}, 100)
 	for {
 		var err error
 		class, err := stream.Recv()
@@ -340,8 +340,15 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 	var insertCount int32
 	var errorCount int32
 
-	elementStream := make(chan *gdbi.GraphElement, 100)
+	elementStream := make(chan *gdbi.GraphElement, 50)
 	wg := &sync.WaitGroup{}
+
+	defer func() {
+		if elementStream != nil {
+			close(elementStream)
+		}
+		wg.Wait()
+	}()
 
 	for {
 		element, err := stream.Recv()
@@ -364,7 +371,10 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 		// create a BulkAdd stream per graph
 		// close and switch when a new graph is encountered
 		if element.Graph != graphName {
-			close(elementStream)
+			if elementStream != nil {
+				close(elementStream)
+				wg.Wait()
+			}
 			gdb, err := server.getGraphDB(element.Graph)
 			if err != nil {
 				errorCount++
@@ -379,10 +389,10 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 			}
 
 			graphName = element.Graph
-			elementStream = make(chan *gdbi.GraphElement, 100)
+			elementStream = make(chan *gdbi.GraphElement, 50)
 
 			wg.Add(1)
-			go func() {
+			go func(graphName string, stream chan *gdbi.GraphElement) {
 				log.WithFields(log.Fields{"graph": element.Graph}).Info("BulkAdd: streaming elements to graph")
 				err := graph.BulkAdd(elementStream)
 				if err != nil {
@@ -391,7 +401,7 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 					errorCount++
 				}
 				wg.Done()
-			}()
+			}(graphName, elementStream)
 		}
 
 		if element.Vertex != nil {
@@ -420,9 +430,6 @@ func (server *GripServer) BulkAdd(stream gripql.Edit_BulkAddServer) error {
 			}
 		}
 	}
-
-	close(elementStream)
-	wg.Wait()
 
 	return stream.SendAndClose(&gripql.BulkEditResult{InsertCount: insertCount, ErrorCount: errorCount})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bmeg/grip/config"
@@ -42,15 +43,16 @@ type GripServer struct {
 	gripql.UnimplementedEditServer
 	gripql.UnimplementedJobServer
 	gripql.UnimplementedConfigureServer
-	dbs      map[string]gdbi.GraphDB  //graph database drivers
-	graphMap map[string]string        //mapping from graph name to graph database driver
-	conf     *config.Config           //global configuration
-	schemas  map[string]*gripql.Graph //cached schemas
-	mappings map[string]*gripql.Graph //cached gripper graph mappings
-	plugins  map[string]*Plugin
-	sources  map[string]gripper.GRIPSourceClient
-	baseDir  string
-	jStorage jobstorage.JobStorage
+	dbs        map[string]gdbi.GraphDB  //graph database drivers
+	graphMap   map[string]string        //mapping from graph name to graph database driver
+	conf       *config.Config           //global configuration
+	schemas    map[string]*gripql.Graph //cached schemas
+	mappings   map[string]*gripql.Graph //cached gripper graph mappings
+	plugins    map[string]*Plugin
+	sources    map[string]gripper.GRIPSourceClient
+	baseDir    string
+	jStorage   jobstorage.JobStorage
+	streamPool *sync.Pool
 }
 
 // NewGripServer initializes a GRPC server to connect to the graph store
@@ -92,13 +94,21 @@ func NewGripServer(conf *config.Config, baseDir string, drivers map[string]gdbi.
 		}
 	}
 
+	// Add an element pool for managing resources when streaming data
+	var graphElementPool = &sync.Pool{
+		New: func() interface{} {
+			return &gdbi.GraphElement{}
+		},
+	}
+
 	server := &GripServer{
-		dbs:      gdbs,
-		conf:     conf,
-		schemas:  schemas,
-		mappings: map[string]*gripql.Graph{},
-		plugins:  map[string]*Plugin{},
-		sources:  sources,
+		dbs:        gdbs,
+		conf:       conf,
+		schemas:    schemas,
+		mappings:   map[string]*gripql.Graph{},
+		plugins:    map[string]*Plugin{},
+		sources:    sources,
+		streamPool: graphElementPool,
 	}
 
 	if conf.Default == "" {

--- a/sqlite/graph.go
+++ b/sqlite/graph.go
@@ -77,6 +77,131 @@ func (g *Graph) AddVertex(vertices []*gdbi.Vertex) error {
 	return nil
 }
 
+func (g *Graph) StreamVertices(vertices <-chan *gdbi.Vertex, workers int) error {
+	txn, err := g.db.Begin()
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Begin Txn: %v", err)
+	}
+
+	s := fmt.Sprintf(
+		`INSERT INTO %s (gid, label, data) VALUES ($1, $2, $3)
+		 ON CONFLICT (gid) DO UPDATE SET
+		 gid = excluded.gid,
+		 label = excluded.label,
+		 data = excluded.data;`,
+		g.v,
+	)
+	stmt, err := txn.Prepare(s)
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Prepare Stmt: %v", err)
+	}
+
+	count := 0
+	for v := range vertices {
+		js, err := json.Marshal(v.Data)
+		if err != nil {
+			return fmt.Errorf("StreamVertices: Stmt.Exec: %v", err)
+		}
+		_, err = stmt.Exec(v.ID, v.Label, js)
+		if err != nil {
+			return fmt.Errorf("StreamVertices: Stmt.Exec: %v", err)
+		}
+		count++
+
+		if count%1000 == 0 {
+			if err := txn.Commit(); err != nil {
+				_ = stmt.Close()
+				return fmt.Errorf("StreamVertices: Txn.Commit: %v", err)
+			}
+
+			txn, err = g.db.Begin()
+			if err != nil {
+				return fmt.Errorf("StreamVertices: Begin New Txn: %v", err)
+			}
+			stmt, err = txn.Prepare(s)
+			if err != nil {
+				return fmt.Errorf("StreamVertices: Prepare New Stmt: %v", err)
+			}
+		}
+
+	}
+
+	err = stmt.Close()
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Stmt.Close: %v", err)
+	}
+
+	err = txn.Commit()
+	if err != nil {
+		return fmt.Errorf("StreamVertices: Txn.Commit: %v", err)
+	}
+
+	return nil
+}
+
+func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
+	txn, err := g.db.Begin()
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Begin Txn: %v", err)
+	}
+
+	s := fmt.Sprintf(
+		`INSERT INTO %s (gid, label, "from", "to", data) VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (gid) DO UPDATE SET
+		gid = excluded.gid,
+		label = excluded.label,
+		"from" = excluded."from",
+		"to" = excluded."to",
+		data = excluded.data;`,
+		g.e,
+	)
+	stmt, err := txn.Prepare(s)
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Prepare Stmt: %v", err)
+	}
+
+	count := 0
+	for e := range edges {
+		js, err := json.Marshal(e.Data)
+		if err != nil {
+			return fmt.Errorf("AddEdge: Stmt.Exec: %v", err)
+		}
+		_, err = stmt.Exec(e.ID, e.Label, e.From, e.To, js)
+		if err != nil {
+			return fmt.Errorf("AddEdge: Stmt.Exec: %v", err)
+		}
+		count++
+		if count%1000 == 0 {
+			if err := txn.Commit(); err != nil {
+				_ = stmt.Close()
+				return fmt.Errorf("StreamEdges: Txn.Commit: %v", err)
+			}
+
+			txn, err = g.db.Begin()
+			if err != nil {
+				return fmt.Errorf("StreamEdges: Begin New Txn: %v", err)
+			}
+			stmt, err = txn.Prepare(s)
+			if err != nil {
+				return fmt.Errorf("StreamEdges: Prepare New Stmt: %v", err)
+			}
+		}
+
+	}
+
+	err = stmt.Close()
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Stmt.Close: %v", err)
+	}
+
+	err = txn.Commit()
+	if err != nil {
+		return fmt.Errorf("StreamEdges: Txn.Commit: %v", err)
+	}
+
+	return nil
+}
+
 func (g *Graph) AddEdge(edges []*gdbi.Edge) error {
 	txn, err := g.db.Begin()
 	if err != nil {
@@ -161,7 +286,7 @@ func (g *Graph) GetEdge(gid string, load bool) *gdbi.Edge {
 }
 
 func (g *Graph) BulkAdd(stream <-chan *gdbi.GraphElement) error {
-	return util.StreamBatch(stream, 50, g.graph, g.AddVertex, g.AddEdge)
+	return util.StreamBatch(stream, 50, g.graph, g.StreamVertices, g.StreamEdges)
 }
 
 func (g *Graph) BulkDel(Data *gdbi.DeleteData) error {

--- a/sqlite/graph.go
+++ b/sqlite/graph.go
@@ -96,7 +96,6 @@ func (g *Graph) StreamVertices(vertices <-chan *gdbi.Vertex, workers int) error 
 		return fmt.Errorf("StreamVertices: Prepare Stmt: %v", err)
 	}
 
-	count := 0
 	for v := range vertices {
 		js, err := json.Marshal(v.Data)
 		if err != nil {
@@ -105,23 +104,6 @@ func (g *Graph) StreamVertices(vertices <-chan *gdbi.Vertex, workers int) error 
 		_, err = stmt.Exec(v.ID, v.Label, js)
 		if err != nil {
 			return fmt.Errorf("StreamVertices: Stmt.Exec: %v", err)
-		}
-		count++
-
-		if count%1000 == 0 {
-			if err := txn.Commit(); err != nil {
-				_ = stmt.Close()
-				return fmt.Errorf("StreamVertices: Txn.Commit: %v", err)
-			}
-
-			txn, err = g.db.Begin()
-			if err != nil {
-				return fmt.Errorf("StreamVertices: Begin New Txn: %v", err)
-			}
-			stmt, err = txn.Prepare(s)
-			if err != nil {
-				return fmt.Errorf("StreamVertices: Prepare New Stmt: %v", err)
-			}
 		}
 
 	}
@@ -160,7 +142,6 @@ func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
 		return fmt.Errorf("StreamEdges: Prepare Stmt: %v", err)
 	}
 
-	count := 0
 	for e := range edges {
 		js, err := json.Marshal(e.Data)
 		if err != nil {
@@ -169,22 +150,6 @@ func (g *Graph) StreamEdges(edges <-chan *gdbi.Edge, workers int) error {
 		_, err = stmt.Exec(e.ID, e.Label, e.From, e.To, js)
 		if err != nil {
 			return fmt.Errorf("AddEdge: Stmt.Exec: %v", err)
-		}
-		count++
-		if count%1000 == 0 {
-			if err := txn.Commit(); err != nil {
-				_ = stmt.Close()
-				return fmt.Errorf("StreamEdges: Txn.Commit: %v", err)
-			}
-
-			txn, err = g.db.Begin()
-			if err != nil {
-				return fmt.Errorf("StreamEdges: Begin New Txn: %v", err)
-			}
-			stmt, err = txn.Prepare(s)
-			if err != nil {
-				return fmt.Errorf("StreamEdges: Prepare New Stmt: %v", err)
-			}
 		}
 
 	}

--- a/util/insert.go
+++ b/util/insert.go
@@ -1,12 +1,14 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
 	"github.com/bmeg/grip/gdbi"
 	"github.com/bmeg/grip/log"
 	multierror "github.com/hashicorp/go-multierror"
+	"golang.org/x/sync/semaphore"
 )
 
 // StreamBatch a stream of inputs and loads them into the graph
@@ -20,7 +22,8 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 	vertexChan := make(chan *gdbi.Vertex, batchSize)
 	edgeChan := make(chan *gdbi.Edge, batchSize)
 
-	// Start goroutines to process vertices and edges
+	sem := semaphore.NewWeighted(int64(batchSize * 2))
+
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
@@ -57,6 +60,7 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 				continue
 			}
 
+			sem.Acquire(context.Background(), 1)
 			vertexBatch = append(vertexBatch, vertex)
 			vertCount++
 
@@ -64,7 +68,8 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 				for _, v := range vertexBatch {
 					vertexChan <- v
 				}
-				vertexBatch = vertexBatch[:0] // Reset batch slice
+				vertexBatch = make([]*gdbi.Vertex, 0, batchSize)
+				sem.Release(int64(len(vertexBatch)))
 			}
 		} else if element.Edge != nil {
 			edge := element.Edge
@@ -80,6 +85,7 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 				continue
 			}
 
+			sem.Acquire(context.Background(), 1)
 			edgeBatch = append(edgeBatch, edge)
 			edgeCount++
 
@@ -87,7 +93,8 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 				for _, e := range edgeBatch {
 					edgeChan <- e
 				}
-				edgeBatch = edgeBatch[:0] // Reset batch slice
+				edgeBatch = make([]*gdbi.Edge, 0, batchSize)
+				sem.Release(int64(len(edgeBatch)))
 			}
 		}
 	}
@@ -105,6 +112,7 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 	close(edgeChan)
 
 	wg.Wait()
+	sem.Release(int64(len(vertexBatch) + len(edgeBatch)))
 
 	if vertCount != 0 {
 		log.Debugf("%d vertices streamed to BulkAdd", vertCount)

--- a/util/insert.go
+++ b/util/insert.go
@@ -65,11 +65,12 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 			vertCount++
 
 			if len(vertexBatch) >= batchSize {
+				batchSizeToRelease := len(vertexBatch)
 				for _, v := range vertexBatch {
 					vertexChan <- v
 				}
 				vertexBatch = make([]*gdbi.Vertex, 0, batchSize)
-				sem.Release(int64(len(vertexBatch)))
+				sem.Release(int64(batchSizeToRelease))
 			}
 		} else if element.Edge != nil {
 			edge := element.Edge
@@ -90,11 +91,12 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 			edgeCount++
 
 			if len(edgeBatch) >= batchSize {
+				batchSizeToRelease := len(edgeBatch)
 				for _, e := range edgeBatch {
 					edgeChan <- e
 				}
 				edgeBatch = make([]*gdbi.Edge, 0, batchSize)
-				sem.Release(int64(len(edgeBatch)))
+				sem.Release(int64(batchSizeToRelease))
 			}
 		}
 	}

--- a/util/insert.go
+++ b/util/insert.go
@@ -11,39 +11,29 @@ import (
 
 // StreamBatch a stream of inputs and loads them into the graph
 // This function assumes incoming stream is GraphElemnts from a single graph
-func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, vertexAdd func([]*gdbi.Vertex) error, edgeAdd func([]*gdbi.Edge) error) error {
-
+func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, vertexAdd func(<-chan *gdbi.Vertex, int) error, edgeAdd func(<-chan *gdbi.Edge, int) error) error {
 	var bulkErr *multierror.Error
 	vertCount := 0
 	edgeCount := 0
-	vertexBatchChan := make(chan []*gdbi.Vertex)
-	edgeBatchChan := make(chan []*gdbi.Edge)
 	wg := &sync.WaitGroup{}
 
-	wg.Add(1)
+	vertexChan := make(chan *gdbi.Vertex, batchSize)
+	edgeChan := make(chan *gdbi.Edge, batchSize)
+
+	// Start goroutines to process vertices and edges
+	wg.Add(2)
 	go func() {
-		for vBatch := range vertexBatchChan {
-			if len(vBatch) > 0 {
-				err := vertexAdd(vBatch)
-				if err != nil {
-					bulkErr = multierror.Append(bulkErr, err)
-				}
-			}
+		defer wg.Done()
+		if err := vertexAdd(vertexChan, batchSize); err != nil {
+			bulkErr = multierror.Append(bulkErr, err)
 		}
-		wg.Done()
 	}()
 
-	wg.Add(1)
 	go func() {
-		for eBatch := range edgeBatchChan {
-			if len(eBatch) > 0 {
-				err := edgeAdd(eBatch)
-				if err != nil {
-					bulkErr = multierror.Append(bulkErr, err)
-				}
-			}
+		defer wg.Done()
+		if err := edgeAdd(edgeChan, batchSize); err != nil {
+			bulkErr = multierror.Append(bulkErr, err)
 		}
-		wg.Done()
 	}()
 
 	vertexBatch := make([]*gdbi.Vertex, 0, batchSize)
@@ -55,45 +45,66 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 				bulkErr,
 				fmt.Errorf("unexpected graph reference: %s != %s", element.Graph, graph),
 			)
-		} else if element.Vertex != nil {
-			if len(vertexBatch) >= batchSize {
-				vertexBatchChan <- vertexBatch
-				vertexBatch = make([]*gdbi.Vertex, 0, batchSize)
-			}
+			continue
+		}
+		if element.Vertex != nil {
 			vertex := element.Vertex
-			err := vertex.Validate()
-			if err != nil {
+			if err := vertex.Validate(); err != nil {
 				bulkErr = multierror.Append(
 					bulkErr,
 					fmt.Errorf("vertex validation failed: %v", err),
 				)
-			} else {
-				vertexBatch = append(vertexBatch, vertex)
-				vertCount++
+				continue
+			}
+
+			vertexBatch = append(vertexBatch, vertex)
+			vertCount++
+
+			if len(vertexBatch) >= batchSize {
+				for _, v := range vertexBatch {
+					vertexChan <- v
+				}
+				vertexBatch = vertexBatch[:0] // Reset batch slice
 			}
 		} else if element.Edge != nil {
-			if len(edgeBatch) >= batchSize {
-				edgeBatchChan <- edgeBatch
-				edgeBatch = make([]*gdbi.Edge, 0, batchSize)
-			}
 			edge := element.Edge
 			if edge.ID == "" {
 				edge.ID = UUID()
 			}
-			err := edge.Validate()
-			if err != nil {
+
+			if err := edge.Validate(); err != nil {
 				bulkErr = multierror.Append(
 					bulkErr,
 					fmt.Errorf("edge validation failed: %v", err),
 				)
-			} else {
-				edgeBatch = append(edgeBatch, edge)
-				edgeCount++
+				continue
+			}
+
+			edgeBatch = append(edgeBatch, edge)
+			edgeCount++
+
+			if len(edgeBatch) >= batchSize {
+				for _, e := range edgeBatch {
+					edgeChan <- e
+				}
+				edgeBatch = edgeBatch[:0] // Reset batch slice
 			}
 		}
 	}
-	vertexBatchChan <- vertexBatch
-	edgeBatchChan <- edgeBatch
+
+	// Send remaining vertices and edges in the batch
+	for _, v := range vertexBatch {
+		vertexChan <- v
+	}
+	for _, e := range edgeBatch {
+		edgeChan <- e
+	}
+
+	// Close channels after all data is sent
+	close(vertexChan)
+	close(edgeChan)
+
+	wg.Wait()
 
 	if vertCount != 0 {
 		log.Debugf("%d vertices streamed to BulkAdd", vertCount)
@@ -102,10 +113,6 @@ func StreamBatch(stream <-chan *gdbi.GraphElement, batchSize int, graph string, 
 	if edgeCount != 0 {
 		log.Debugf("%d edges streamed to BulkAdd", edgeCount)
 	}
-
-	close(edgeBatchChan)
-	close(vertexBatchChan)
-	wg.Wait()
 
 	return bulkErr.ErrorOrNil()
 }


### PR DESCRIPTION
Reworks bulk add raw so that rows are generated and sent to BulkAdd protobuf method sequentially. 

This makes it so that instead of exponential RAM usage, only the bare minimum RAM that is needed to generate the edges and send them to channels is used, but a bit more CPU is used.

Reworks driver helper functions and stream insert helper function so that batch inserts happen at the driver level using channels instead of collecting elements from channel and appending to a list and then passing that to the driver insert functions.

Adds a semaphore to the insert util function to limit the amount of data in the chan. This probably isn't needed but I think it might help with stability.

Working with current data