### PR TITLE
Fixes bugs with bulk delete function. Improves bulk delete function t…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Workiva/go-datastructures v1.1.5
 	github.com/akrylysov/pogreb v0.10.2
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10
-	github.com/bmeg/benchtop v0.0.0-20250826173532-50ea19466c1c
+	github.com/bmeg/benchtop v0.0.0-20250827195345-9810354883b9
 	github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad
 	github.com/bmeg/jsonschema/v5 v5.3.4-0.20241111204732-55db82022a92
 	github.com/bmeg/jsonschemagraph v0.0.3-0.20250330060023-8f61d8bfec9a

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Workiva/go-datastructures v1.1.5
 	github.com/akrylysov/pogreb v0.10.2
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10
-	github.com/bmeg/benchtop v0.0.0-20250821231639-df57ed2bb713
+	github.com/bmeg/benchtop v0.0.0-20250826173532-50ea19466c1c
 	github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad
 	github.com/bmeg/jsonschema/v5 v5.3.4-0.20241111204732-55db82022a92
 	github.com/bmeg/jsonschemagraph v0.0.3-0.20250330060023-8f61d8bfec9a

--- a/go.sum
+++ b/go.sum
@@ -35,14 +35,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bmeg/benchtop v0.0.0-20250818194308-7b4d6a6bfa36 h1:frNXEP0pgmYHu7WDgaXLrsf/pB4hv1SMT6SMK+bVk1g=
-github.com/bmeg/benchtop v0.0.0-20250818194308-7b4d6a6bfa36/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
-github.com/bmeg/benchtop v0.0.0-20250818195147-fd718212c311 h1:oEc44MjeTPX8DArCOrg/DBQDtT7xrfhz6q8ScfYmJj8=
-github.com/bmeg/benchtop v0.0.0-20250818195147-fd718212c311/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
-github.com/bmeg/benchtop v0.0.0-20250821165736-18d0cca965bb h1:k3md0eKLb80Ve/fYuNh8komOw9qD00NVho+n/G9ZQus=
-github.com/bmeg/benchtop v0.0.0-20250821165736-18d0cca965bb/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
-github.com/bmeg/benchtop v0.0.0-20250821231639-df57ed2bb713 h1:VsdsDhvfnagpEOBc6Hu8SNxYbMvyxkYGr1pVARmktEQ=
-github.com/bmeg/benchtop v0.0.0-20250821231639-df57ed2bb713/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
+github.com/bmeg/benchtop v0.0.0-20250826173532-50ea19466c1c h1:JjsqIMnoIihXqdf52UuK4MZOEa1RIppaNhK2ahuNqbQ=
+github.com/bmeg/benchtop v0.0.0-20250826173532-50ea19466c1c/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
 github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad h1:ICgBexeLB7iv/IQz4rsP+MimOXFZUwWSPojEypuOaQ8=
 github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad/go.mod h1:ft96Irkp72C7ZrUWRenG7LrF0NKMxXdRvsypo5Njhm4=
 github.com/bmeg/jsonschema/v5 v5.3.4-0.20241111204732-55db82022a92 h1:Myx/j+WxfEg+P3nDaizR1hBpjKSLgvr4ydzgp1/1pAU=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bmeg/benchtop v0.0.0-20250826173532-50ea19466c1c h1:JjsqIMnoIihXqdf52UuK4MZOEa1RIppaNhK2ahuNqbQ=
-github.com/bmeg/benchtop v0.0.0-20250826173532-50ea19466c1c/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
+github.com/bmeg/benchtop v0.0.0-20250827195345-9810354883b9 h1:sIgPwNZKv3pSuIm/hngszbBrg3pKlZcyJ+HTzeFyjNA=
+github.com/bmeg/benchtop v0.0.0-20250827195345-9810354883b9/go.mod h1:Jy39KqCHrPeU9J3SEAdVnZ5dxE6VZm8tX899z5n6ud8=
 github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad h1:ICgBexeLB7iv/IQz4rsP+MimOXFZUwWSPojEypuOaQ8=
 github.com/bmeg/jsonpath v0.0.0-20210207014051-cca5355553ad/go.mod h1:ft96Irkp72C7ZrUWRenG7LrF0NKMxXdRvsypo5Njhm4=
 github.com/bmeg/jsonschema/v5 v5.3.4-0.20241111204732-55db82022a92 h1:Myx/j+WxfEg+P3nDaizR1hBpjKSLgvr4ydzgp1/1pAU=

--- a/grids/graph.go
+++ b/grids/graph.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime"
+	"slices"
+	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bmeg/benchtop"
 	"github.com/bmeg/benchtop/jsontable"
@@ -13,6 +17,8 @@ import (
 	"github.com/bmeg/grip/gdbi"
 	"github.com/bmeg/grip/log"
 	"github.com/bmeg/grip/util/setcmp"
+	"github.com/bytedance/sonic"
+	"github.com/cockroachdb/pebble"
 	multierror "github.com/hashicorp/go-multierror"
 )
 
@@ -76,7 +82,18 @@ func (ggraph *Graph) indexVertex(vertex *gdbi.Vertex, tx *pebblebulk.PebbleBulk)
 	if fieldsExist {
 		for field := range ggraph.jsonkv.Fields[vertexLabel] {
 			if val := jsontable.PathLookup(vertex.Data, field); val != nil {
-				tx.Set(benchtop.FieldKey(field, vertexLabel, val, []byte(vertex.ID)), []byte{}, nil)
+				err := tx.Set(benchtop.FieldKey(field, vertexLabel, val, []byte(vertex.ID)), []byte{}, nil)
+				if err != nil {
+					return err
+				}
+				Mval, err := sonic.ConfigFastest.Marshal(val)
+				if err != nil {
+					return err
+				}
+				err = tx.Set(benchtop.RFieldKey(vertexLabel, field, vertex.ID), Mval, nil)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -150,7 +167,18 @@ func (ggraph *Graph) indexEdge(edge *gdbi.Edge, tx *pebblebulk.PebbleBulk) error
 	if fieldsExist {
 		for field := range ggraph.jsonkv.Fields[edgeLabel] {
 			if val := jsontable.PathLookup(edge.Data, field); val != nil {
-				tx.Set(benchtop.FieldKey(field, edgeLabel, val, []byte(edge.ID)), []byte{}, nil)
+				err := tx.Set(benchtop.FieldKey(field, edgeLabel, val, []byte(edge.ID)), []byte{}, nil)
+				if err != nil {
+					return err
+				}
+				eMarsh, err := sonic.ConfigFastest.Marshal(val)
+				if err != nil {
+					return err
+				}
+				err = tx.Set(benchtop.RFieldKey(edgeLabel, field, edge.ID), eMarsh, nil)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -223,34 +251,6 @@ func (ggraph *Graph) AddEdge(edges []*gdbi.Edge) error {
 	})
 	return err
 
-}
-
-func (ggraph *Graph) BulkDel(data *gdbi.DeleteData) error {
-	var bulkErr *multierror.Error
-	ggraph.tempDeletedEdges = make(map[string]struct{})
-	ggraph.edgesMutex.Lock()
-
-	for _, val := range data.Vertices {
-		err := ggraph.DelVertex(val)
-		if err != nil {
-			bulkErr = multierror.Append(bulkErr, err)
-		}
-	}
-
-	for _, val := range data.Edges {
-		if _, ok := ggraph.tempDeletedEdges[val]; ok {
-			log.Debugf("Skipping edge %s: already deleted during vertex deletion", val)
-			continue
-		}
-		err := ggraph.DelEdge(val)
-		if err != nil {
-			bulkErr = multierror.Append(bulkErr, err)
-		}
-	}
-
-	ggraph.tempDeletedEdges = nil // Clean up
-	defer ggraph.edgesMutex.Unlock()
-	return bulkErr.ErrorOrNil()
 }
 
 func (ggraph *Graph) BulkAdd(stream <-chan *gdbi.GraphElement) error {
@@ -343,7 +343,6 @@ func (ggraph *Graph) DelVertex(id string) error {
 	edgesToDelete := make(map[string]string)
 
 	var bulkErr *multierror.Error
-
 	err := ggraph.jsonkv.Pb.View(func(it *pebblebulk.PebbleIterator) error {
 		for it.Seek(skeyPrefix); it.Valid() && bytes.HasPrefix(it.Key(), skeyPrefix); it.Next() {
 			skey := it.Key()
@@ -397,6 +396,19 @@ func (ggraph *Graph) DelVertex(id string) error {
 		if ggraph.tempDeletedEdges != nil {
 			ggraph.tempDeletedEdges[eid] = struct{}{}
 		}
+	}
+
+	loc, err := ggraph.jsonkv.PageCache.Get(context.Background(), id, ggraph.jsonkv.PageLoader)
+	if err != nil {
+		return err
+	}
+
+	label := ggraph.jsonkv.LabelLookup[loc.Label]
+	if label == "" {
+		bulkErr = multierror.Append(bulkErr, fmt.Errorf("Failed to lookup table label %d", loc.Label))
+	}
+	if err := ggraph.DeleteAnyRow(id, label, false); err != nil {
+		bulkErr = multierror.Append(bulkErr, err)
 	}
 
 	err = ggraph.jsonkv.Pb.BulkWrite(func(tx *pebblebulk.PebbleBulk) error {
@@ -942,4 +954,455 @@ func (ggraph *Graph) ListEdgeLabels() ([]string, error) {
 		labels = append(labels, i)
 	}
 	return labels, nil
+}
+
+// New Bulk Delete Function. Testing...
+// BulkDel deletes vertices and edges in bulk.
+func (ggraph *Graph) BulkDel(data *gdbi.DeleteData) error {
+	type keyBatch struct {
+		singles [][]byte
+		ranges  [][2][]byte
+		posKeys [][]byte
+	}
+
+	type itemInfo struct {
+		id     string
+		label  string
+		isEdge bool
+		tbl    string
+	}
+
+	type fieldInfo struct {
+		rKey  []byte
+		field string
+		tbl   string
+		id    []byte
+	}
+
+	const shardSize = 64
+	const bufferSize = 8192
+	numCpus := runtime.NumCPU()
+	ctx := context.Background()
+
+	var bulkErr *multierror.Error
+	addErr := func(err error) {
+		if err != nil {
+			bulkErr = multierror.Append(bulkErr, err)
+		}
+	}
+
+	// Sharded bitmap for edge deduplication (lock-free for reads)
+	type shard struct {
+		mu    sync.Mutex
+		set   map[string]struct{}
+		count uint32 // Atomic counter for seen edges
+	}
+	shards := make([]*shard, shardSize)
+	for i := range shards {
+		shards[i] = &shard{set: make(map[string]struct{}, bufferSize/shardSize)}
+	}
+	hasSeenEdge := func(eid string) bool {
+		h := fnv32a(eid) % uint32(shardSize)
+		shard := shards[h]
+		shard.mu.Lock()
+		defer shard.mu.Unlock()
+		if _, exists := shard.set[eid]; exists {
+			return true
+		}
+		shard.set[eid] = struct{}{}
+		atomic.AddUint32(&shard.count, 1)
+		return false
+	}
+	getSeenCount := func() uint64 {
+		var total uint64
+		for _, shard := range shards {
+			total += uint64(atomic.LoadUint32(&shard.count))
+		}
+		return total
+	}
+
+	// Channels and wait groups
+	itemChan := make(chan itemInfo, bufferSize)
+	fieldChan := make(chan fieldInfo, bufferSize)
+	keyChan := make(chan keyBatch, bufferSize)
+	var prodWG, consWG, aggWG, fieldWG sync.WaitGroup
+
+	// Aggregator for keys
+	var singles [][]byte
+	var ranges [][2][]byte
+	var posKeys [][]byte
+	aggWG.Add(1)
+	go func() {
+		defer aggWG.Done()
+		for batch := range keyChan {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				singles = append(singles, batch.singles...)
+				ranges = append(ranges, batch.ranges...)
+				posKeys = append(posKeys, batch.posKeys...)
+			}
+		}
+	}()
+
+	// Aggregator for fields
+	var allFields []fieldInfo
+	fieldWG.Add(1)
+	go func() {
+		defer fieldWG.Done()
+		for fi := range fieldChan {
+			allFields = append(allFields, fi)
+		}
+	}()
+
+	// Workers for items
+	consWG.Add(numCpus)
+	for range numCpus {
+		go func() {
+			defer consWG.Done()
+			localBatch := keyBatch{posKeys: make([][]byte, 0, bufferSize)}
+			i := 0
+			for item := range itemChan {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				if i%100_000 == 0 && i != 0 {
+					log.Debugf("[BulkDel worker] processed %d items", i)
+				}
+				i++
+
+				// Fetch from page cache
+				loc, err := ggraph.jsonkv.PageCache.Get(ctx, item.id, ggraph.jsonkv.PageLoader)
+				if err != nil {
+					addErr(err)
+					continue
+				}
+
+				// Mark table for deletion
+				table, ok := ggraph.jsonkv.Tables[item.tbl]
+				if !ok {
+					addErr(fmt.Errorf("table %s not found", item.tbl))
+					continue
+				}
+				if err := table.MarkDeleteTable(loc); err != nil {
+					addErr(err)
+				}
+
+				// Position key
+				localBatch.posKeys = append(localBatch.posKeys, benchtop.NewPosKey(loc.Label, []byte(item.id)))
+				ggraph.jsonkv.PageCache.Invalidate(item.id)
+
+				// Send field infos
+				if fields, exists := ggraph.jsonkv.Fields[item.tbl]; exists {
+					for field := range fields {
+						rKey := benchtop.RFieldKey(item.tbl, field, item.id)
+						select {
+						case fieldChan <- fieldInfo{rKey: rKey, field: field, tbl: item.tbl, id: []byte(item.id)}:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+
+				if len(localBatch.posKeys) >= 500_000 {
+					keyChan <- localBatch
+					localBatch = keyBatch{posKeys: make([][]byte, 0, bufferSize)}
+				}
+			}
+
+			if len(localBatch.posKeys) > 0 {
+				keyChan <- localBatch
+			}
+		}()
+	}
+
+	// Prepare vertex producers
+	slices.Sort(data.Vertices)
+	vertexSlices := make([][]string, numCpus)
+	for i, vid := range data.Vertices {
+		vertexSlices[i%numCpus] = append(vertexSlices[i%numCpus], vid)
+	}
+	for i := range vertexSlices {
+		slices.Sort(vertexSlices[i])
+	}
+
+	for _, slice := range vertexSlices {
+		if len(slice) == 0 {
+			continue
+		}
+		prodWG.Add(1)
+		go func(slice []string) {
+			defer prodWG.Done()
+			localBatch := keyBatch{singles: make([][]byte, 0, 256), ranges: make([][2][]byte, 0, 256)}
+
+			err := ggraph.jsonkv.Pb.View(func(it *pebblebulk.PebbleIterator) error {
+				for _, vid := range slice {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+					}
+
+					sPrefix := SrcEdgePrefix(vid)
+					if err := it.Seek(sPrefix); err != nil {
+						return err
+					}
+					if it.Valid() && bytes.HasPrefix(it.Key(), sPrefix) {
+						nextPrefix := upperBound(sPrefix)
+						if nextPrefix != nil {
+							localBatch.ranges = append(localBatch.ranges, [2][]byte{sPrefix, nextPrefix})
+						}
+						for it.Valid() && bytes.HasPrefix(it.Key(), sPrefix) {
+							eid, sid, did, lbl := SrcEdgeKeyParse(it.Key())
+							if !hasSeenEdge(eid) {
+								localBatch.singles = append(localBatch.singles,
+									EdgeKey(eid, sid, did, lbl),
+									bytes.Clone(it.Key()),
+									DstEdgeKey(eid, sid, did, lbl))
+								select {
+								case itemChan <- itemInfo{id: eid, label: lbl, isEdge: true, tbl: ETABLE_PREFIX + lbl}:
+								case <-ctx.Done():
+									return ctx.Err()
+								}
+							}
+							it.Next()
+						}
+					}
+
+					dPrefix := DstEdgePrefix(vid)
+					if err := it.Seek(dPrefix); err != nil {
+						return err
+					}
+					if it.Valid() && bytes.HasPrefix(it.Key(), dPrefix) {
+						nextPrefix := upperBound(dPrefix)
+						if nextPrefix != nil {
+							localBatch.ranges = append(localBatch.ranges, [2][]byte{dPrefix, nextPrefix})
+						}
+						for it.Valid() && bytes.HasPrefix(it.Key(), dPrefix) {
+							eid, sid, did, lbl := DstEdgeKeyParse(it.Key())
+							if !hasSeenEdge(eid) {
+								localBatch.singles = append(localBatch.singles,
+									EdgeKey(eid, sid, did, lbl),
+									SrcEdgeKey(eid, sid, did, lbl),
+									bytes.Clone(it.Key()))
+								select {
+								case itemChan <- itemInfo{id: eid, label: lbl, isEdge: true, tbl: ETABLE_PREFIX + lbl}:
+								case <-ctx.Done():
+									return ctx.Err()
+								}
+							}
+							it.Next()
+						}
+					}
+
+					vkey := VertexKey(vid)
+					if err := it.Seek(vkey); err != nil {
+						return err
+					}
+					var label string
+					if it.Valid() && bytes.Equal(it.Key(), vkey) {
+						labelBytes, err := it.Value()
+						if err != nil {
+							return err
+						}
+						label = string(labelBytes)
+					}
+					localBatch.singles = append(localBatch.singles, vkey)
+					if label != "" {
+						select {
+						case itemChan <- itemInfo{id: vid, label: label, isEdge: false, tbl: VTABLE_PREFIX + label}:
+						case <-ctx.Done():
+							return ctx.Err()
+						}
+					}
+				}
+				return nil
+			})
+			addErr(err)
+
+			if len(localBatch.singles) > 0 || len(localBatch.ranges) > 0 {
+				select {
+				case keyChan <- localBatch:
+				case <-ctx.Done():
+				}
+			}
+		}(slice)
+	}
+
+	// Prepare edge producers
+	slices.Sort(data.Edges)
+	edgeSlices := make([][]string, numCpus)
+	for i, eid := range data.Edges {
+		edgeSlices[i%numCpus] = append(edgeSlices[i%numCpus], eid)
+	}
+	for i := range edgeSlices {
+		slices.Sort(edgeSlices[i])
+	}
+
+	for _, slice := range edgeSlices {
+		if len(slice) == 0 {
+			continue
+		}
+		prodWG.Add(1)
+		go func(slice []string) {
+			defer prodWG.Done()
+			localBatch := keyBatch{singles: make([][]byte, 0, 12), ranges: make([][2][]byte, 0, 12)}
+
+			err := ggraph.jsonkv.Pb.View(func(it *pebblebulk.PebbleIterator) error {
+				for _, eid := range slice {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+					}
+
+					if hasSeenEdge(eid) {
+						continue
+					}
+
+					prefix := EdgeKeyPrefix(eid)
+					if err := it.Seek(prefix); err != nil {
+						return err
+					}
+					if it.Valid() && bytes.HasPrefix(it.Key(), prefix) {
+						nextPrefix := upperBound(prefix)
+						if nextPrefix != nil {
+							localBatch.ranges = append(localBatch.ranges, [2][]byte{prefix, nextPrefix})
+						}
+						var label string
+						for it.Valid() && bytes.HasPrefix(it.Key(), prefix) {
+							_, sid, did, lbl := EdgeKeyParse(it.Key())
+							label = lbl
+							localBatch.singles = append(localBatch.singles,
+								SrcEdgeKey(eid, sid, did, lbl),
+								DstEdgeKey(eid, sid, did, lbl))
+							it.Next()
+						}
+						if label != "" {
+							select {
+							case itemChan <- itemInfo{id: eid, label: label, isEdge: true, tbl: ETABLE_PREFIX + label}:
+							case <-ctx.Done():
+								return ctx.Err()
+							}
+						}
+					}
+				}
+				return nil
+			})
+			addErr(err)
+
+			if len(localBatch.singles) > 0 || len(localBatch.ranges) > 0 {
+				select {
+				case keyChan <- localBatch:
+				case <-ctx.Done():
+				}
+			}
+		}(slice)
+	}
+
+	// Close channels and wait
+	go func() {
+		prodWG.Wait()
+		close(itemChan)
+	}()
+	consWG.Wait()
+	close(keyChan)
+	aggWG.Wait()
+	close(fieldChan)
+	fieldWG.Wait()
+
+	// Process field indices with single iterator
+	var indexDelKeys [][]byte
+	if len(allFields) > 0 {
+		sort.Slice(allFields, func(i, j int) bool {
+			return bytes.Compare(allFields[i].rKey, allFields[j].rKey) < 0
+		})
+		err := ggraph.jsonkv.Pb.View(func(it *pebblebulk.PebbleIterator) error {
+			for _, fi := range allFields {
+				if err := it.Seek(fi.rKey); err != nil {
+					return err
+				}
+				if it.Valid() && bytes.Equal(it.Key(), fi.rKey) {
+					valueBytes, err := it.Value()
+					if err != nil {
+						return err
+					}
+					var fieldValue any
+					if err := sonic.ConfigFastest.Unmarshal(valueBytes, &fieldValue); err != nil {
+						return err
+					}
+					if fieldValue != nil {
+						fKey := benchtop.FieldKey(fi.field, fi.tbl, fieldValue, fi.id)
+						indexDelKeys = append(indexDelKeys, fKey, fi.rKey)
+					}
+				}
+			}
+			return nil
+		})
+		addErr(err)
+	}
+
+	// Chunked deletes with Pebble batch
+	chunked := func(singles [][]byte, ranges [][2][]byte, posKeys [][]byte, indexDelKeys [][]byte) error {
+		batch := ggraph.jsonkv.Pb.Db.NewBatch()
+		defer batch.Close()
+		for _, k := range singles {
+			if err := batch.Delete(k, nil); err != nil {
+				return err
+			}
+		}
+		for _, r := range ranges {
+			if err := batch.DeleteRange(r[0], r[1], nil); err != nil {
+				return err
+			}
+		}
+		for _, k := range posKeys {
+			if err := batch.Delete(k, nil); err != nil {
+				return err
+			}
+		}
+		for _, k := range indexDelKeys {
+			if err := batch.Delete(k, nil); err != nil {
+				return err
+			}
+		}
+		return batch.Commit(pebble.Sync)
+	}
+
+	// Perform deletes
+	ggraph.jsonkv.PebbleLock.Lock()
+	if err := chunked(singles, ranges, posKeys, indexDelKeys); err != nil {
+		addErr(err)
+	}
+	ggraph.ts.Touch(ggraph.graphID)
+	ggraph.jsonkv.PebbleLock.Unlock()
+
+	log.Debugf("Total edges seen: %d", getSeenCount())
+	return bulkErr.ErrorOrNil()
+}
+
+// upperBound computes the tight upper bound for range delete
+func upperBound(prefix []byte) []byte {
+	ub := make([]byte, len(prefix))
+	copy(ub, prefix)
+	for i := len(ub) - 1; i >= 0; i-- {
+		if ub[i] < 0xFF {
+			ub[i]++
+			return ub[:i+1]
+		}
+	}
+	return nil
+}
+
+// fnv32a computes FNV-1a 32-bit hash
+func fnv32a(s string) uint32 {
+	var h uint32 = 2166136261
+	for i := range s {
+		h ^= uint32(s[i])
+		h *= 16777619
+	}
+	return h
 }

--- a/grids/index.go
+++ b/grids/index.go
@@ -2,10 +2,12 @@ package grids
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/bmeg/grip/gripql"
 	"github.com/bmeg/grip/log"
 	"github.com/cockroachdb/pebble"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 // AddVertexIndex add index to vertices
@@ -16,6 +18,7 @@ func (ggraph *Graph) AddVertexIndex(label, field string) error {
 
 // DeleteVertexIndex delete index from vertices
 func (ggraph *Graph) DeleteVertexIndex(label, field string) error {
+	fmt.Println("HELLO WE HARE HERE")
 	log.WithFields(log.Fields{"label": label, "field": field}).Info("Deleting vertex index")
 	return ggraph.jsonkv.RemoveField(VTABLE_PREFIX+label, field)
 }
@@ -44,23 +47,44 @@ func (ggraph *Graph) VertexLabelScan(ctx context.Context, label string) chan str
 }
 
 func (ggraph *Graph) DeleteAnyRow(id string, label string, edgeFlag bool) error {
-	ggraph.jsonkv.Lock.Lock()
-	defer ggraph.jsonkv.Lock.Unlock()
-
 	var prefix string = "v_"
 	if edgeFlag {
 		prefix = "e_"
 	}
 
-	err := ggraph.jsonkv.Tables[prefix+label].DeleteRow([]byte(id))
+	loc, err := ggraph.jsonkv.PageCache.Get(context.Background(), id, ggraph.jsonkv.PageLoader)
 	if err != nil {
-		if err == pebble.ErrNotFound {
-			log.Debugln("Pebble not Found: %s", err)
-			return nil
-		}
 		return err
 	}
-	ggraph.jsonkv.PageCache.Invalidate(id)
 
-	return nil
+	tableLabel := prefix + label
+	var bulkErr *multierror.Error
+	if fields, exists := ggraph.jsonkv.Fields[tableLabel]; exists {
+		for field := range fields {
+			if err := ggraph.jsonkv.DeleteRowField(tableLabel, field, id); err != nil {
+				log.Errorf("Failed to delete index for field '%s' in table '%s' for row '%s': %v", field, tableLabel, id, err)
+				bulkErr = multierror.Append(bulkErr, err)
+			}
+		}
+	}
+
+	ggraph.jsonkv.PebbleLock.Lock()
+	defer ggraph.jsonkv.PebbleLock.Unlock()
+
+	table, ok := ggraph.jsonkv.Tables[prefix+label]
+	if !ok {
+		bulkErr = multierror.Append(bulkErr, fmt.Errorf("table %s not found in jsonkv.Tables: %#v", prefix+label, ggraph.jsonkv.Tables))
+		return bulkErr.ErrorOrNil()
+	}
+
+	err = table.DeleteRow(loc, []byte(id))
+	if err != nil {
+		if err == pebble.ErrNotFound {
+			log.Debugf("Pebble not Found: %s", err)
+			return nil
+		}
+		bulkErr = multierror.Append(bulkErr, err)
+	}
+	ggraph.jsonkv.PageCache.Invalidate(id)
+	return bulkErr.ErrorOrNil()
 }


### PR DESCRIPTION
Performant bulk delete. Adds field index delete in jsontable driver to fix nasty bug that occurs when delete a project and reload the same project.

Bug was returning graph elements with no "_id" field causing panic since data didn't exist but index still existed. 
Ex:
```
goroutine 37630 [running]:
github.com/bmeg/grip/gdbi.(*DataElement).ToVertex(0x0)
	/go/pkg/mod/github.com/bmeg/grip@v0.0.0-20250714173925-c1892d4f63b1/gdbi/data_element.go:13 +0x17
github.com/bmeg/grip/engine/pipeline.Convert({0x32bcbb0, 0xc00175ced0}, 0xb0?, 0xc00446d6c0?, {0x32b5960?, 0xc009809bc0?})
	/go/pkg/mod/github.com/bmeg/grip@v0.0.0-20250714173925-c1892d4f63b1/engine/pipeline/pipes.go:163 +0x4b9
github.com/bmeg/grip/engine/pipeline.Run.func1()
	/go/pkg/mod/github.com/bmeg/grip@v0.0.0-20250714173925-c1892d4f63b1/engine/pipeline/pipes.go:112 +0x217
created by github.com/bmeg/grip/engine/pipeline.Run in goroutine 37629
	/go/pkg/mod/github.com/bmeg/grip@v0.0.0-20250714173925-c1892d4f63b1/engine/pipeline/pipes.go:103 +0xe5
```

From testing locally and also testing the new grip-caliper image this issue seems to have gone away since indices are deleted for individual rows and as part of the BulkDel function now.