### PR TITLE
Fix for mongo pipeline query hasLabel index access

### DIFF
--- a/engine/core/optimize.go
+++ b/engine/core/optimize.go
@@ -11,6 +11,19 @@ type OptimizationRule struct {
 	Replace func(pipe []*gripql.GraphStatement) []*gripql.GraphStatement
 }
 
+func OptimizeHasLabelMatch(pipe []*gripql.GraphStatement) bool {
+	if len(pipe) < 2 {
+		return false
+	}
+	if _, ok := pipe[0].GetStatement().(*gripql.GraphStatement_V); !ok {
+		return false
+	}
+	if hasLabel, ok := pipe[1].GetStatement().(*gripql.GraphStatement_HasLabel); ok {
+		return len(hasLabel.HasLabel.GetValues()) > 0
+	}
+	return false
+}
+
 // startOptimizations is a list of rules to optimize the query pipeline.
 var startOptimizations = []OptimizationRule{
 	{
@@ -37,18 +50,7 @@ var startOptimizations = []OptimizationRule{
 	},
 	{
 		// Matches V().HasLabel(...)
-		Match: func(pipe []*gripql.GraphStatement) bool {
-			if len(pipe) < 2 {
-				return false
-			}
-			if _, ok := pipe[0].GetStatement().(*gripql.GraphStatement_V); !ok {
-				return false
-			}
-			if hasLabel, ok := pipe[1].GetStatement().(*gripql.GraphStatement_HasLabel); ok {
-				return len(hasLabel.HasLabel.GetValues()) > 0
-			}
-			return false
-		},
+		Match: OptimizeHasLabelMatch,
 		Replace: func(pipe []*gripql.GraphStatement) []*gripql.GraphStatement {
 			labels := protoutil.AsStringList(pipe[1].GetHasLabel())
 			optimized := []*gripql.GraphStatement{

--- a/mongo/compile.go
+++ b/mongo/compile.go
@@ -92,6 +92,23 @@ func (comp *Compiler) Compile(stmts []*gripql.GraphStatement, opts *gdbi.Compile
 	vertCol := fmt.Sprintf("%s_vertices", comp.db.graph)
 	edgeCol := fmt.Sprintf("%s_edges", comp.db.graph)
 
+	if core.OptimizeHasLabelMatch(stmts) {
+		stmt := stmts[1].GetHasLabel()
+		labels := protoutil.AsStringList(stmt)
+		//find by label first
+		query = append(query, bson.D{primitive.E{Key: "$match", Value: bson.M{FIELD_LABEL: bson.M{"$in": labels}}}})
+		startCollection = vertCol
+		query = append(query,
+			bson.D{primitive.E{Key: "$project", Value: bson.M{
+				FIELD_CURRENT: "$$CURRENT",
+				"marks":       "$marks",
+				"path":        []any{bson.M{"vertex": "$_id"}},
+			},
+			}})
+		lastType = gdbi.VertexData
+		stmts = stmts[2:]
+	}
+
 	for _, gs := range stmts {
 		switch stmt := gs.GetStatement().(type) {
 		case *gripql.GraphStatement_V:


### PR DESCRIPTION
Mongo pipeline query not using the _label index correctly at the start of the query
