### PR TITLE
Replace bitnami Kafka image with soldevelo/kafka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ start-kafka:
 		-e KAFKA_CLIENT_PASSWORDS=adminpassword \
 		-e KAFKA_CFG_SASL_ENABLED_MECHANISMS=PLAIN \
 		-e KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN \
-		bitnami/kafka:latest
+		soldevelo/kafka:latest
 	printf '%s\n' \
 		'security.protocol=SASL_PLAINTEXT' \
 		'sasl.mechanism=PLAIN' \


### PR DESCRIPTION
This change updates the Docker image used for Kafka in the Makefile from `bitnami/kafka` to `soldevelo/kafka`.
Soldevelo image is a drop-in replacement that remains fully compatible with Bitnami’s configuration and environment variables.

The Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.
Switching to Soldevelo’s maintained image ensures:
* continued compatibility with existing Kafka setup,
* availability of regular updates and security patches,
* use of an image from a trusted and open source provider.